### PR TITLE
Use specific cargo make version that runs tasks in correct order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           override: true
       - uses: davidB/rust-cargo-make@v1
+        with:
+          version: 0.35.16
       - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: cargo make test-flow

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -591,7 +591,7 @@ mod tests {
         let sdk = || _sdk.lock().unwrap();
         let dir = format!(
             "../target/{}/test_plugin",
-            std::env::var("TEST_TARGET").unwrap_or("/debug".to_owned())
+            std::env::var("TEST_TARGET").unwrap_or("debug".to_owned())
         );
         info!("Loading plugins from: {:?}", dir);
         assert!(!sdk().initialised);


### PR DESCRIPTION
v0.36 breaks the task execution order when running `test-flow`