### PR TITLE
Cleanup to C Plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test CI
 
-on: push
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/includes/plugin.h
+++ b/includes/plugin.h
@@ -15,7 +15,7 @@
 #define ANALOGSDK_API
 #endif
 
-const uint32_t ANALOG_SDK_PLUGIN_ABI_VERSION = 0;
+const uint32_t ANALOG_SDK_PLUGIN_ABI_VERSION = 1;
 
 typedef void (*device_event)(void const *, WootingAnalog_DeviceEventType,
                              const WootingAnalog_DeviceInfo_FFI *);

--- a/includes/plugin.h
+++ b/includes/plugin.h
@@ -1,7 +1,7 @@
+#include "wooting-analog-plugin-dev.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdbool.h>
-#include "wooting-analog-plugin-dev.h"
 
 #if defined(_WIN32) || defined(WIN32)
 #ifdef ANALOGSDK_EXPORTS
@@ -17,36 +17,46 @@
 
 const uint32_t ANALOG_SDK_PLUGIN_ABI_VERSION = 0;
 
-
-typedef void(*device_event)(void*, WootingAnalog_DeviceEventType, WootingAnalog_DeviceInfo*);
+typedef void (*device_event)(void const *, WootingAnalog_DeviceEventType,
+                             const WootingAnalog_DeviceInfo_FFI *);
 
 /// Get a name describing the `Plugin`.
-ANALOGSDK_API const char* _name();
+ANALOGSDK_API const char *name();
 
 /// A callback fired immediately after the plugin is loaded. Usually used
 /// for initialization.
-ANALOGSDK_API int _initialise(void* callback_data, device_event callback);
+ANALOGSDK_API int initialise(void const *callback_data, device_event callback);
 
 /// A function fired to check if the plugin is currently initialised
 ANALOGSDK_API bool is_initialised();
 
 /// A callback fired immediately before the plugin is unloaded. Use this if
-/// you need to do any cleanup.
+/// you need to do any cleanup. Any references to `callback_data` or `callback`
+/// should be dropped as these will be invalidated after this function returns.
 ANALOGSDK_API void unload();
 
-/// Function called to get the full analog read buffer for a particular device with ID `device`. `len` is the maximum amount
-/// of keys that can be accepted, any more beyond this will be ignored by the SDK.
-/// If `device` is 0 then no specific device is specified and the data should be read from all devices and combined
-ANALOGSDK_API int _read_full_buffer(uint16_t code_buffer[], float analog_buffer[], int len, WootingAnalog_DeviceID device);
+/// Function called to get the full analog read buffer for a particular device
+/// with ID `device`. `len` is the maximum amount of keys that can be accepted,
+/// any more beyond this will be ignored by the SDK. If `device` is 0 then no
+/// specific device is specified and the data should be read from all devices
+/// and combined
+ANALOGSDK_API int read_full_buffer(uint16_t code_buffer[],
+                                    float analog_buffer[], int len,
+                                    WootingAnalog_DeviceID device);
 
-/// This function is fired by the SDK to collect up all Device Info structs. The memory for the struct should be retained and only dropped
-/// when the device is disconnected or the plugin is unloaded. This ensures that the Device Info is not garbled when it's being accessed by the client.
+/// This function is fired by the SDK to collect up all Device Info structs. The
+/// memory for the struct should be retained and only dropped when the device is
+/// disconnected or the plugin is unloaded. This ensures that the Device Info is
+/// not garbled when it's being accessed by the client.
 ///
 /// # Notes
 ///
-/// Although, the client should be copying any data they want to use for a prolonged time as there is no lifetime guarantee on the data.
-ANALOGSDK_API int _device_info(WootingAnalog_DeviceInfo* buffer[], int len);
+/// Although, the client should be copying any data they want to use for a
+/// prolonged time as there is no lifetime guarantee on the data.
+ANALOGSDK_API int device_info(const WootingAnalog_DeviceInfo_FFI *buffer[],
+                               int len);
 
-/// Function called to get the analog value for a particular HID key `code` from the device with ID `device`.
-/// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
+/// Function called to get the analog value for a particular HID key `code` from
+/// the device with ID `device`. If `device` is 0 then no specific device is
+/// specified and the value should be read from all devices and combined
 ANALOGSDK_API float read_analog(uint16_t code, WootingAnalog_DeviceID device);

--- a/includes/wooting-analog-common.h
+++ b/includes/wooting-analog-common.h
@@ -100,13 +100,6 @@ typedef enum WootingAnalogResult {
   WootingAnalogResult_DLLNotFound = -1990,
 } WootingAnalogResult;
 
-/**
- * The core `DeviceInfo` struct which contains all the interesting information
- * for a particular device. This is for use internally and should be ignored if you're
- * trying to use it when trying to interact with the SDK using the wrapper
- */
-typedef struct WootingAnalog_DeviceInfo WootingAnalog_DeviceInfo;
-
 typedef uint64_t WootingAnalog_DeviceID;
 
 /**
@@ -141,29 +134,3 @@ typedef struct WootingAnalog_DeviceInfo_FFI {
    */
   enum WootingAnalog_DeviceType device_type;
 } WootingAnalog_DeviceInfo_FFI;
-
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
-
-/**
- * Create a new device info struct. This is only for use in Plugins that are written in C
- * Rust plugins should use the native constructor
- * The memory for the struct has been allocated in Rust. So `drop_device_info` must be called
- * for the memory to be properly released
- */
-struct WootingAnalog_DeviceInfo *new_device_info(uint16_t vendor_id,
-                                                 uint16_t product_id,
-                                                 char *manufacturer_name,
-                                                 char *device_name,
-                                                 WootingAnalog_DeviceID device_id,
-                                                 enum WootingAnalog_DeviceType device_type);
-
-/**
- * Drops the given `DeviceInfo`
- */
-void drop_device_info(struct WootingAnalog_DeviceInfo *device);
-
-#ifdef __cplusplus
-}  // extern "C"
-#endif  // __cplusplus

--- a/wooting-analog-common/src/lib.rs
+++ b/wooting-analog-common/src/lib.rs
@@ -145,39 +145,6 @@ impl DeviceInfo {
     }
 }
 
-/// Create a new device info struct. This is only for use in Plugins that are written in C
-/// Rust plugins should use the native constructor
-/// The memory for the struct has been allocated in Rust. So `drop_device_info` must be called
-/// for the memory to be properly released
-#[no_mangle]
-pub extern "C" fn new_device_info(
-    vendor_id: u16,
-    product_id: u16,
-    manufacturer_name: *mut c_char,
-    device_name: *mut c_char,
-    device_id: DeviceID,
-    device_type: DeviceType,
-) -> *mut DeviceInfo {
-    Box::into_raw(Box::new(DeviceInfo::new_with_id(
-        vendor_id,
-        product_id,
-        unsafe {
-            CStr::from_ptr(manufacturer_name)
-                .to_string_lossy()
-                .into_owned()
-        },
-        unsafe { CStr::from_ptr(device_name).to_string_lossy().into_owned() },
-        device_id,
-        device_type,
-    )))
-}
-
-/// Drops the given `DeviceInfo`
-#[no_mangle]
-pub unsafe extern "C" fn drop_device_info(device: *mut DeviceInfo) {
-    drop(Box::from_raw(device));
-}
-
 #[cfg_attr(feature = "serdes", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone, Primitive)]
 #[repr(C)]

--- a/wooting-analog-sdk/build.rs
+++ b/wooting-analog-sdk/build.rs
@@ -1,13 +1,13 @@
 const TEST_PLUGIN_DIR: &str = "test_c_plugin";
 
 fn main() {
-    // println!("Building Test C Plugin");
-    // println!("{:?}", std::env::var("OUT_DIR"));
+    println!("Building Test C Plugin");
+    println!("{:?}", std::env::var("OUT_DIR"));
 
-    // cmake::Config::new(TEST_PLUGIN_DIR)
-    //     .no_build_target(true)
-    //     .out_dir(format!("./{}", TEST_PLUGIN_DIR))
-    //     .always_configure(false)
-    //     .profile("Debug")
-    //     .build();
+    cmake::Config::new(TEST_PLUGIN_DIR)
+        .no_build_target(true)
+        .out_dir(format!("./{}", TEST_PLUGIN_DIR))
+        .always_configure(false)
+        .profile("Debug")
+        .build();
 }

--- a/wooting-analog-sdk/src/cplugin.rs
+++ b/wooting-analog-sdk/src/cplugin.rs
@@ -67,7 +67,7 @@ macro_rules! lib_wrap_option {
     };
 }
 
-const CPLUGIN_ABI_VERSION: u32 = 0;
+const CPLUGIN_ABI_VERSION: u32 = 1;
 
 pub struct CPlugin {
     lib: Library,

--- a/wooting-analog-sdk/src/cplugin.rs
+++ b/wooting-analog-sdk/src/cplugin.rs
@@ -2,7 +2,6 @@ use ffi_support::FfiStr;
 use libloading::{Library, Symbol};
 use log::*;
 use std::collections::HashMap;
-use std::ffi::CStr;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort, c_void};
 use wooting_analog_common::*;
 use wooting_analog_plugin_dev::*;
@@ -72,6 +71,7 @@ const CPLUGIN_ABI_VERSION: u32 = 0;
 
 pub struct CPlugin {
     lib: Library,
+    cb_data_ptr: Option<*mut Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>>,
     //funcs: HashMap<&'static str, Option<Symbol>>
 }
 
@@ -93,22 +93,32 @@ impl CPlugin {
 
         Ok(CPlugin {
             lib,
-            //funcs: HashMap::new()
+            cb_data_ptr: None, //funcs: HashMap::new()
         })
         .into()
     }
 
     lib_wrap_option! {
         //c_name has to be over here due to it not being part of the Plugin trait
-        fn _initialise(data: *mut c_void, callback: extern "C" fn(*mut c_void, DeviceEventType, *mut DeviceInfo)) -> i32;
-        fn _name() -> FfiStr<'static>;
+        fn initialise(data: *const c_void, callback: extern "C" fn(*mut c_void, DeviceEventType, *const DeviceInfo_FFI)) -> i32;
+        fn name() -> FfiStr<'static>;
 
-        fn _read_full_buffer(code_buffer: *const c_ushort, analog_buffer: *const c_float, len: c_uint, device: DeviceID) -> c_int;
-        fn _device_info(buffer: *mut *mut DeviceInfo_FFI, len: c_uint) -> c_int;
+        fn read_analog(code: u16, device: DeviceID) -> f32;
+        fn read_full_buffer(code_buffer: *const c_ushort, analog_buffer: *const c_float, len: c_uint, device: DeviceID) -> c_int;
+        fn device_info(buffer: *mut *const DeviceInfo_FFI, len: c_uint) -> c_int;
+    }
+
+    lib_wrap! {
+        fn is_initialised() -> bool;
+        fn unload();
     }
 }
 
-extern "C" fn call_closure(data: *mut c_void, event: DeviceEventType, device_raw: *mut DeviceInfo) {
+extern "C" fn call_closure(
+    data: *mut c_void,
+    event: DeviceEventType,
+    device_raw: *const DeviceInfo_FFI,
+) {
     debug!("Got into the callclosure");
     unsafe {
         if data.is_null() {
@@ -116,23 +126,21 @@ extern "C" fn call_closure(data: *mut c_void, event: DeviceEventType, device_raw
             return;
         }
 
-        let device = Box::from_raw(device_raw);
+        let device_info = device_raw.as_ref().unwrap().into_device_info();
 
         let callback_ptr =
             Box::from_raw(data as *mut Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>);
 
-        (*callback_ptr)(event, &device);
+        (*callback_ptr)(event, &device_info);
+
         //Throw it back into raw to prevent it being dropped so the callback can be called multiple times
         Box::into_raw(callback_ptr);
-        //We also want to convert this back to a pointer as we want the C Plugin to be in control and aware of
-        //when this memory is being dropped
-        Box::into_raw(device);
     }
 }
 
 impl Plugin for CPlugin {
     fn name(&mut self) -> SDKResult<&'static str> {
-        self._name().0.map(|s| s.as_str()).into()
+        self.name().0.map(|s| s.as_str()).into()
     }
 
     fn initialise(
@@ -140,10 +148,15 @@ impl Plugin for CPlugin {
         callback: Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
     ) -> SDKResult<u32> {
         let data = Box::into_raw(Box::new(callback));
-        self._initialise(data as *mut _, call_closure)
+        self.cb_data_ptr = Some(data);
+        self.initialise(data as *const _, call_closure)
             .0
             .map(|res| res as u32)
             .into()
+    }
+
+    fn read_analog(&mut self, code: u16, device: DeviceID) -> SDKResult<f32> {
+        self.read_analog(code, device).0.into()
     }
 
     fn read_full_buffer(
@@ -157,7 +170,7 @@ impl Plugin for CPlugin {
         analog_buffer.resize(max_length, 0.0);
         let count: usize = {
             let ret = self
-                ._read_full_buffer(
+                .read_full_buffer(
                     code_buffer.as_ptr(),
                     analog_buffer.as_ptr(),
                     max_length as c_uint,
@@ -182,10 +195,10 @@ impl Plugin for CPlugin {
     }
 
     fn device_info(&mut self) -> SDKResult<Vec<DeviceInfo>> {
-        let mut device_infos: Vec<*mut DeviceInfo_FFI> = vec![std::ptr::null_mut(); 10];
+        let mut device_infos: Vec<*const DeviceInfo_FFI> = vec![std::ptr::null_mut(); 10];
 
         match self
-            ._device_info(device_infos.as_mut_ptr(), device_infos.len() as c_uint)
+            .device_info(device_infos.as_mut_ptr(), device_infos.len() as c_uint)
             .0
             .map(|no| no as u32)
         {
@@ -193,16 +206,7 @@ impl Plugin for CPlugin {
                 device_infos.truncate(num as usize);
                 let devices = device_infos
                     .drain(..)
-                    .map(|dev| {
-                        DeviceInfo {
-                            vendor_id: (*dev).vendor_id,
-                            product_id: (*dev).product_id,
-                            manufacturer_name: CStr::from_ptr((*dev).manufacturer_name).to_str().unwrap().to_owned(),
-                            device_name: CStr::from_ptr((*dev).device_name).to_str().unwrap().to_owned(),
-                            device_id: (*dev).device_id,
-                            device_type: (*dev).device_type.clone(),
-                        }
-                    })
+                    .map(|dev| dev.as_ref().unwrap().into_device_info())
                     .collect();
                 Ok(devices).into()
             },
@@ -210,12 +214,19 @@ impl Plugin for CPlugin {
         }
     }
 
-    lib_wrap! {
-        fn is_initialised() -> bool;
-        fn unload();
+    fn is_initialised(&mut self) -> bool {
+        self.is_initialised()
     }
-    lib_wrap_option! {
-        fn read_analog(code: u16, device: DeviceID) -> f32;
-        //fn neg(x: u32, y: u32) -> u32;
+
+    fn unload(&mut self) {
+        self.unload();
+        // Drop cb_data_ptr
+        if let Some(ptr) = self.cb_data_ptr {
+            unsafe {
+                drop(Box::from_raw(
+                    ptr as *mut Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
+                ));
+            }
+        }
     }
 }

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -360,6 +360,7 @@ mod tests {
     use std::sync::{Arc, MutexGuard};
     use std::time::Duration;
 
+    #[derive(Debug, PartialEq)]
     struct SharedState {
         pub vendor_id: u16,
         /// Device Product ID `pid`
@@ -369,8 +370,6 @@ mod tests {
         pub manufacturer_name: [u8; 20],
         /// Device name
         pub device_name: [u8; 20],
-        /// Unique device ID, which should be generated using `generate_device_id`
-        pub device_id: u64,
 
         pub device_type: DeviceType,
 
@@ -533,7 +532,7 @@ mod tests {
             let mut shared_state = get_wlock(&mut shmem);
             shared_state.analog_values[analog_key] = analog_val;
             shared_state.device_connected = true;
-            shared_state.device_id
+            1
         };
 
         wait_for_connected(5, true);

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -34,10 +34,10 @@ pub extern "C" fn wooting_analog_initialise() -> c_int {
     trace!("catch unwind result: {:?}", result);
     match result {
         Ok(c) => c,
-        Err(e) =>{
+        Err(e) => {
             error!("An error occurred in wooting_analog_initialise: {:?}", e);
             WootingAnalogResult::Failure.into()
-        } ,
+        }
     }
 }
 
@@ -72,7 +72,7 @@ pub extern "C" fn wooting_analog_uninitialise() -> WootingAnalogResult {
             if let Some(mut old_devices) = old {
                 for dev in old_devices.drain(..) {
                     unsafe {
-                        Box::from_raw(dev);
+                        drop(Box::from_raw(dev));
                     }
                 }
             }
@@ -195,7 +195,7 @@ pub extern "C" fn wooting_analog_set_device_event_cb(
             cb(event, device_raw);
             //We need to box up the pointer again to ensure it is properly dropped
             unsafe {
-                Box::from_raw(device_raw);
+                drop(Box::from_raw(device_raw));
             }
         })
         .into()
@@ -253,7 +253,7 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
                 if let Some(mut old_devices) = old {
                     for dev in old_devices.drain(..) {
                         unsafe {
-                            Box::from_raw(dev);
+                            drop(Box::from_raw(dev));
                         }
                     }
                 }

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -515,7 +515,7 @@ mod tests {
     unsafe impl SharedMemCast for SharedState {}
 
     fn shared_init() {
-        env_logger::try_init_from_env(env_logger::Env::from("trace"))
+        env_logger::try_init_from_env(env_logger::Env::from("debug"))
             .map_err(|e| println!("ERROR: Could not initialise env_logger. '{:?}'", e));
     }
 
@@ -800,7 +800,7 @@ mod tests {
         let got_cb_inner = got_cb.clone();
 
         sdk.set_device_event_cb(move |event, device| {
-            debug!("We got that callbackkkk");
+            println!("We got that callbackkkk {:?} {:?}", event, device);
             got_cb_inner.store(true, Ordering::Relaxed);
 
             //A couple of basic checks to ensure the callback gets valid data
@@ -813,6 +813,7 @@ mod tests {
         assert_eq!(sdk.read_analog(30, 0).0, Ok(0.56));
         assert_eq!(sdk.read_full_buffer(30, 0).0.unwrap().get(&5), Some(&0.4));
         let device = sdk.get_device_info().0.unwrap().first().unwrap().clone();
+        println!("Got device: {:?}", device);
         assert_eq!(device.device_id, 7);
 
         //Wait a wee bit to ensure the callback has been executed

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -501,8 +501,6 @@ mod tests {
         pub manufacturer_name: [u8; 20],
         /// Device name
         pub device_name: [u8; 20],
-        /// Unique device ID, which should be generated using `generate_device_id`
-        pub device_id: u64,
 
         pub device_type: DeviceType,
 
@@ -676,7 +674,7 @@ mod tests {
             let mut shared_state = get_wlock(&mut shmem);
             shared_state.analog_values[analog_key] = analog_val;
             shared_state.device_connected = true;
-            shared_state.device_id
+            1
         };
 
         wait_for_connected(&got_connected, 5, true);

--- a/wooting-analog-sdk/test_c_plugin/CMakeLists.txt
+++ b/wooting-analog-sdk/test_c_plugin/CMakeLists.txt
@@ -6,9 +6,3 @@ set(analog_sdk_path ${CMAKE_CURRENT_SOURCE_DIR}/../../)
 link_directories($ENV{OUT_DIR}/../../../)
 
 add_library(analog_plugin_c SHARED src/plugin.c)
-if (WIN32)
-    # On Windows bcrypt needs to be linked as well for the rust libs
-    target_link_libraries(analog_plugin_c PRIVATE bcrypt)
-endif (WIN32)
-target_link_libraries(analog_plugin_c PRIVATE wooting_analog_plugin_dev)
-target_link_libraries(analog_plugin_c PRIVATE wooting_analog_common)

--- a/wooting-analog-sdk/test_c_plugin/src/plugin.c
+++ b/wooting-analog-sdk/test_c_plugin/src/plugin.c
@@ -1,66 +1,82 @@
 #include "../../../includes/plugin.h"
 
 static bool initialised = false;
-static WootingAnalog_DeviceInfo* deviceInfo;
-
+static WootingAnalog_DeviceInfo_FFI deviceInfo;
 
 /// Get a name describing the `Plugin`.
-const char* _name() {
-    return "C Test plugin";
-}
+const char *name() { return "C Test plugin"; }
 
-static void* cb_data;
+static void const *cb_data;
 static device_event cb;
 
 /// A callback fired immediately after the plugin is loaded. Usually used
 /// for initialization.
-int _initialise(void* callback_data, device_event callback) {
+int initialise(void const *callback_data, device_event callback) {
 
-    cb_data = callback_data;
-    cb = callback;
+  cb_data = callback_data;
+  cb = callback;
 
-    initialised = true;
-    deviceInfo = new_device_info(5,6, "Yeet", "Yeet", 7, WootingAnalog_DeviceType_Keyboard);
-    return 1;
+  initialised = true;
+  // deviceInfo = new_device_info(5,6, "Yeet", "Yeet", 7,
+  // WootingAnalog_DeviceType_Keyboard);
+  deviceInfo.vendor_id = 5;
+  deviceInfo.product_id = 6;
+  deviceInfo.device_name = "Yeet";
+  deviceInfo.manufacturer_name = "Yeet";
+  deviceInfo.device_id = 7;
+  deviceInfo.device_type = WootingAnalog_DeviceType_Keyboard;
+
+  return 1;
 }
 
 /// A function fired to check if the plugin is currently initialised
-bool is_initialised(){
-    return initialised;
-}
+bool is_initialised() { return initialised; }
 
 /// A callback fired immediately before the plugin is unloaded. Use this if
 /// you need to do any cleanup.
 void unload() {
-    drop_device_info(deviceInfo);
+  initialised = false;
+  cb_data = NULL;
+  cb = NULL;
 }
 
-/// Function called to get the full analog read buffer for a particular device with ID `device`. `len` is the maximum amount
-/// of keys that can be accepted, any more beyond this will be ignored by the SDK.
-/// If `device` is 0 then no specific device is specified and the data should be read from all devices and combined
-int _read_full_buffer(uint16_t code_buffer[], float analog_buffer[], int len, WootingAnalog_DeviceID device){
-    code_buffer[0] = 5;
-    analog_buffer[0] = 0.4f;
-    return 1;
+/// Function called to get the full analog read buffer for a particular device
+/// with ID `device`. `len` is the maximum amount of keys that can be accepted,
+/// any more beyond this will be ignored by the SDK. If `device` is 0 then no
+/// specific device is specified and the data should be read from all devices
+/// and combined
+int read_full_buffer(uint16_t code_buffer[], float analog_buffer[], int len,
+                      WootingAnalog_DeviceID device) {
+  code_buffer[0] = 5;
+  analog_buffer[0] = 0.4f;
+  return 1;
 }
 
-/// This function is fired by the SDK to collect up all Device Info structs. The memory for the struct should be retained and only dropped
-/// when the device is disconnected or the plugin is unloaded. This ensures that the Device Info is not garbled when it's being accessed by the client.
+/// This function is fired by the SDK to collect up all Device Info structs. The
+/// memory for the struct should be retained and only dropped when the device is
+/// disconnected or the plugin is unloaded. This ensures that the Device Info is
+/// not garbled when it's being accessed by the client.
 ///
 /// # Notes
 ///
-/// Although, the client should be copying any data they want to use for a prolonged time as there is no lifetime guarantee on the data.
-int _device_info(WootingAnalog_DeviceInfo* buffer[], int len) {
-    buffer[0] = deviceInfo;
-    return 1;
+/// Although, the client should be copying any data they want to use for a
+/// prolonged time as there is no lifetime guarantee on the data.
+int device_info(const WootingAnalog_DeviceInfo_FFI *buffer[], int len) {
+  buffer[0] = &deviceInfo;
+  return 1;
 }
 
-/// Function called to get the analog value for a particular HID key `code` from the device with ID `device`.
-/// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
+/// Function called to get the analog value for a particular HID key `code` from
+/// the device with ID `device`. If `device` is 0 then no specific device is
+/// specified and the value should be read from all devices and combined
 float read_analog(uint16_t code, WootingAnalog_DeviceID device) {
-    printf("Calling cb, cb: %p, cb_data: %p, devInfo: %p\n", cb, cb_data, &deviceInfo);
-    cb(cb_data, WootingAnalog_DeviceEventType_Connected, deviceInfo);
+  printf("Calling cb, cb: %p, cb_data: %p, devInfo: %p\n", cb, cb_data,
+         &deviceInfo);
+  if (cb != NULL && cb_data != NULL) {
+    cb(cb_data, WootingAnalog_DeviceEventType_Connected, &deviceInfo);
+  } else {
+    printf("Attempted to execute a NULL callback\n");
+  }
 
-
-    return 0.56f;
+  return 0.56f;
 }

--- a/wooting-analog-test-plugin/src/lib.rs
+++ b/wooting-analog-test-plugin/src/lib.rs
@@ -25,6 +25,7 @@ struct WootingAnalogTestPlugin {
     worker_thread: Option<JoinHandle<()>>,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct SharedState {
     pub vendor_id: u16,
     /// Device Product ID `pid`
@@ -67,7 +68,6 @@ impl WootingAnalogTestPlugin {
 
         let worker_thread = thread::spawn(move || {
             let link_path = std::env::temp_dir().join("wooting-test-plugin.link");
-
             let mut my_shmem = {
                 match SharedMem::open_linked(link_path.as_os_str()) {
                     Ok(v) => v,
@@ -112,6 +112,7 @@ impl WootingAnalogTestPlugin {
                 shared_state.manufacturer_name[0..src.len()].copy_from_slice(src);
                 let src = b"Test Device\x00";
                 shared_state.device_name[0..src.len()].copy_from_slice(src);
+                shared_state.analog_values = [0; 0xFF];
             }
 
             let mut vals = vec![0; 0xFF];
@@ -146,6 +147,7 @@ impl WootingAnalogTestPlugin {
                         );
                         t_device.lock().unwrap().replace(dev);
                     }
+
                     if *t_device_connected.lock().unwrap() != state.device_connected {
                         *t_device_connected.lock().unwrap() = state.device_connected;
                         if let Some(device) = t_device.lock().unwrap().as_ref() {


### PR DESCRIPTION
- Remove need to allocate DeviceInfo in rust from a c plugin. We just let them use the FFI type and we copy the data over
- Eliminate _prefix on some funcs
- Remove dangling pointer to callback_data on cplugin unload
- Add some const qualifiers to things that should never be mutated
- Cleanup some warnings from instances of Box::from_raw that were intended to drop the object, but weren't calling drop on them

TODO:
- [ ] Review the example in this repo and ensure it is valid and up to date: https://github.com/WootingKb/wooting-analog-plugin-examples