### PR TITLE
Further C plugin cleanup

### DIFF
--- a/includes/plugin.h
+++ b/includes/plugin.h
@@ -15,7 +15,7 @@
 #define ANALOGSDK_API
 #endif
 
-const uint32_t ANALOG_SDK_PLUGIN_ABI_VERSION = 0;
+const uint32_t ANALOG_SDK_PLUGIN_ABI_VERSION = 1;
 
 typedef void (*device_event)(void const *, WootingAnalog_DeviceEventType,
                              const WootingAnalog_DeviceInfo_FFI *);

--- a/wooting-analog-common/src/lib.rs
+++ b/wooting-analog-common/src/lib.rs
@@ -145,39 +145,6 @@ impl DeviceInfo {
     }
 }
 
-/// Create a new device info struct. This is only for use in Plugins that are written in C
-/// Rust plugins should use the native constructor
-/// The memory for the struct has been allocated in Rust. So `drop_device_info` must be called
-/// for the memory to be properly released
-#[no_mangle]
-pub extern "C" fn new_device_info(
-    vendor_id: u16,
-    product_id: u16,
-    manufacturer_name: *mut c_char,
-    device_name: *mut c_char,
-    device_id: DeviceID,
-    device_type: DeviceType,
-) -> *mut DeviceInfo {
-    Box::into_raw(Box::new(DeviceInfo::new_with_id(
-        vendor_id,
-        product_id,
-        unsafe {
-            CStr::from_ptr(manufacturer_name)
-                .to_string_lossy()
-                .into_owned()
-        },
-        unsafe { CStr::from_ptr(device_name).to_string_lossy().into_owned() },
-        device_id,
-        device_type,
-    )))
-}
-
-/// Drops the given `DeviceInfo`
-#[no_mangle]
-pub unsafe extern "C" fn drop_device_info(device: *mut DeviceInfo) {
-    drop(Box::from_raw(device));
-}
-
 #[cfg_attr(feature = "serdes", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone, Primitive)]
 #[repr(C)]

--- a/wooting-analog-sdk/src/cplugin.rs
+++ b/wooting-analog-sdk/src/cplugin.rs
@@ -67,7 +67,7 @@ macro_rules! lib_wrap_option {
     };
 }
 
-const CPLUGIN_ABI_VERSION: u32 = 0;
+const CPLUGIN_ABI_VERSION: u32 = 1;
 
 pub struct CPlugin {
     lib: Library,

--- a/wooting-analog-sdk/test_c_plugin/CMakeLists.txt
+++ b/wooting-analog-sdk/test_c_plugin/CMakeLists.txt
@@ -6,9 +6,3 @@ set(analog_sdk_path ${CMAKE_CURRENT_SOURCE_DIR}/../../)
 link_directories($ENV{OUT_DIR}/../../../)
 
 add_library(analog_plugin_c SHARED src/plugin.c)
-if (WIN32)
-    # On Windows bcrypt needs to be linked as well for the rust libs
-    target_link_libraries(analog_plugin_c PRIVATE bcrypt)
-endif (WIN32)
-target_link_libraries(analog_plugin_c PRIVATE wooting_analog_plugin_dev)
-target_link_libraries(analog_plugin_c PRIVATE wooting_analog_common)


### PR DESCRIPTION
Since we're now removing the need for C plugins to link against the Rust code, some simplifications can be made:

- Simplify CMakeLists for test_c_plugin
- Remove new_device_info & drop_device_info

This also fixes the longstanding problems with the `cargo build` failing for most people.

Another thing is bumping the ABI version since everything written prior to the changes made today will not work anymore.