### PR TITLE
Fix wooting-analog-plugin instability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,15 +3103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,12 +3935,10 @@ dependencies = [
 name = "wooting-analog-plugin"
 version = "0.7.0"
 dependencies = [
- "chrono",
  "env_logger 0.7.1",
  "hidapi",
  "log",
  "objekt",
- "timer",
  "wooting-analog-plugin-dev",
 ]
 

--- a/wooting-analog-plugin/Cargo.toml
+++ b/wooting-analog-plugin/Cargo.toml
@@ -17,8 +17,6 @@ wooting-analog-plugin-dev = { path = "../wooting-analog-plugin-dev"}
 hidapi = { version = "^1.2", features = ["linux-static-hidraw"], default-features = false }
 env_logger = "^0.7"
 objekt = "^0.1"
-timer = "^0.2"
-chrono = "^0.4"
 
 [lib]
 crate-type = ["cdylib"]

--- a/wooting-analog-plugin/src/lib.rs
+++ b/wooting-analog-plugin/src/lib.rs
@@ -557,6 +557,7 @@ impl Plugin for WootingPlugin {
         if let Some(t) = self.thread.take() {
             t.join().unwrap();
         };
+        self.devices.lock().unwrap().drain();
 
         info!("{} unloaded", PLUGIN_NAME);
     }


### PR DESCRIPTION
Also removes about 2 MB of bloat from the DLL (debug build anyway).

This timer crate was causing the plugin to randomly crash on drop, so I crudely reimplemented what it did by using `initialised` as a signal variable for the thread to stop.

This should also fix #18 depending on what was meant by "Cannot re-initialise." In my quick before & after test, I found the same "crash on drop" issue before, and it works fine after.