### PR TITLE
Update plugin.h for ABIv1

### DIFF
--- a/includes/plugin.h
+++ b/includes/plugin.h
@@ -9,8 +9,6 @@
 #else
 #define ANALOGSDK_EXPORT __declspec(dllimport)
 #endif
-#pragma comment(lib, "userenv.lib")
-#pragma comment(lib, "WS2_32")
 #else
 #define ANALOGSDK_EXPORT
 #endif

--- a/includes/plugin.h
+++ b/includes/plugin.h
@@ -21,7 +21,7 @@
 #define ANALOGSDK_API ANALOGSDK_EXPORT
 #endif
 
-const uint32_t ANALOG_SDK_PLUGIN_ABI_VERSION = 1;
+ANALOGSDK_API const uint32_t ANALOG_SDK_PLUGIN_ABI_VERSION = 1;
 
 typedef void (*device_event)(void const *, WootingAnalog_DeviceEventType,
                              const WootingAnalog_DeviceInfo_FFI *);

--- a/wooting-analog-sdk/test_c_plugin/src/plugin.c
+++ b/wooting-analog-sdk/test_c_plugin/src/plugin.c
@@ -1,3 +1,4 @@
+#define ANALOGSDK_EXPORTS
 #include "../../../includes/plugin.h"
 
 static bool initialised = false;


### PR DESCRIPTION
I have a PR ready for `wooting-analog-plugin-examples`, but it's based on these changes. At least the export of `ANALOG_SDK_PLUGIN_ABI_VERSION` is required.