### PR TITLE
Fix panic with wooting_analog_get_connected_devices_info

### DIFF
--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -241,8 +241,8 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
             devices.truncate(device_no);
             // Convert all the DeviceInfo's into DeviceInfo_C pointers
             let c_devices: Vec<*mut DeviceInfo_FFI> = devices
-                .drain(..)
-                .map(|dev| Box::into_raw(Box::new(dev.into())))
+                .iter()
+                .map(|dev| Box::into_raw(Box::new((*dev).clone().into())))
                 .collect();
 
             buff.swap_with_slice(c_devices.clone().as_mut());


### PR DESCRIPTION
There seems to have been an instance where swap_with_slice panicked because `c_devices.len()` was `0` for some reason when using the example C plugin.

I'm no Rust expert, but this logic seems to be working to correctly map `devices` into `c_devices`. Tested with various plugins.