### PR TITLE
Don't restrict VirtualKey mode to Windows only

### DIFF
--- a/SDK_USAGE.md
+++ b/SDK_USAGE.md
@@ -105,7 +105,7 @@ By default, the mode is set to HID
 
 ### Notes
 
-- `VirtualKey` and `VirtualKeyTranslate` are only available on Windows
+- `VirtualKeyTranslate` is only available on Windows
 - With all modes except `VirtualKeyTranslate`, the key identifier will point to the physical key on the standard layout. i.e. if you ask for the Q key, it will be the key right to tab regardless of the layout you have selected
 - With `VirtualKeyTranslate`, if you request Q, it will be the key that inputs Q on the current layout, not the key that is Q on the standard layout.
 
@@ -165,9 +165,9 @@ The `device_id` can be found through calling [Get Device Info](#get-connected-de
 ```
 wooting_analog_set_mode(KeycodeType::ScanCode1);
 wooting_analog_read_analog(0x10); //This will get you the value for the key which is Q in the standard US layout (The key just right to tab)
-wooting_analog_set_mode(KeycodeType::VirtualKey); //This will only work on Windows
+wooting_analog_set_mode(KeycodeType::VirtualKey);
 wooting_analog_read_analog(0x51); //This will get you the value for the key that is Q on the standard layout
-wooting_analog_set_mode(KeycodeType::VirtualKeyTranslate); //Also will only work on Windows
+wooting_analog_set_mode(KeycodeType::VirtualKeyTranslate); //This will only work on Windows
 wooting_analog_read_analog(0x51); //This will get you the value for the key that inputs Q on the current layout
 ```
 

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -105,11 +105,11 @@ pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalog
         return WootingAnalogResult::UnInitialized;
     }
 
-    //TODO: Make it return invalid argument when attempting to use virutal keys on platforms other than win
+    //TODO: Make it return invalid argument when attempting to use VirtualKeyTranslate on platforms other than win
     if let Some(key_mode) = KeycodeType::from_u32(mode) {
         #[cfg(not(windows))]
         {
-            if key_mode == KeycodeType::VirtualKey || key_mode == KeycodeType::VirtualKeyTranslate {
+            if key_mode == KeycodeType::VirtualKeyTranslate {
                 return WootingAnalogResult::NotAvailable;
             }
         }


### PR DESCRIPTION
Since this no longer uses any Windows-specific APIs, should be fine to allow it. It's a bit niche, but I know some game engines use VKs as the basis for their internal keycode mappings.