### PR TITLE
Update shared_memory crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,12 +1075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "gethostname"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,15 +1747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memrange"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc29ba65898edc4fdc252cb31cd3925f37c1a8ba25bb46eec883569984976530"
-dependencies = [
- "rustc-serialize",
-]
-
-[[package]]
 name = "metal"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,23 +1942,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.10.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fd5681d13fda646462cfbd4e5f2051279a89a544d50eb98c365b507246839f"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
  "bitflags",
- "bytes",
- "cfg-if 0.1.10",
- "gcc",
+ "cc",
+ "cfg-if 1.0.0",
  "libc",
- "void",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
 name = "nix"
-version = "0.22.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
  "bitflags",
  "cc",
@@ -2356,16 +2340,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -2676,12 +2650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,18 +2802,15 @@ dependencies = [
 
 [[package]]
 name = "shared_memory"
-version = "0.8.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be289420c5900abb177b756f39625ca7a0df68069cfb242fb31feb6e8c480f04"
+checksum = "ba8593196da75d9dc4f69349682bd4c2099f8cde114257d1ef7ef1b33d1aba54"
 dependencies = [
- "cfg-if 0.1.10",
- "enum_primitive",
+ "cfg-if 1.0.0",
  "libc",
- "memrange",
- "nix 0.10.0",
- "rand 0.4.6",
- "theban_interval_tree",
- "winapi 0.3.9",
+ "nix 0.23.2",
+ "rand 0.8.5",
+ "win-sys",
 ]
 
 [[package]]
@@ -3061,17 +3026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "theban_interval_tree"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b42a5385db9a651628091edcd1d58ac9cb1c92327d8cd2a29bf8e35bdfe4ea"
-dependencies = [
- "memrange",
- "rand 0.3.23",
- "time",
 ]
 
 [[package]]
@@ -3400,12 +3354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "want"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,6 +3644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "win-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7b128a98c1cfa201b09eb49ba285887deb3cbe7466a98850eb1adabb452be5"
+dependencies = [
+ "windows",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,6 +3716,19 @@ dependencies = [
  "clipboard_x11",
  "raw-window-handle 0.3.4",
  "thiserror",
+]
+
+[[package]]
+name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
 ]
 
 [[package]]
@@ -3836,6 +3806,12 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
@@ -3851,6 +3827,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3872,6 +3854,12 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
@@ -3887,6 +3875,12 @@ name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3917,6 +3911,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/wooting-analog-sdk/Cargo.toml
+++ b/wooting-analog-sdk/Cargo.toml
@@ -25,7 +25,7 @@ wooting-analog-common = { path = "../wooting-analog-common"}
 wooting-analog-plugin-dev = { path = "../wooting-analog-plugin-dev"}
 
 [dev-dependencies]
-shared_memory = "^0.8"
+shared_memory = "^0.12"
 
 [build-dependencies]
 cmake = "0.1"

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -353,9 +353,7 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 mod tests {
     use super::*;
     use crate::keycode::hid_to_code;
-    use shared_memory::{
-        ReadLockGuard, ReadLockable, SharedMem, SharedMemCast, WriteLockGuard, WriteLockable,
-    };
+    use shared_memory::ShmemConf;
 
     use std::sync::{Arc, MutexGuard};
     use std::time::Duration;
@@ -378,8 +376,6 @@ mod tests {
 
         pub analog_values: [u8; 0xFF],
     }
-
-    unsafe impl SharedMemCast for SharedState {}
 
     pub fn get_sdk() -> MutexGuard<'static, AnalogSDK> {
         ANALOG_SDK.lock().unwrap()
@@ -407,20 +403,6 @@ mod tests {
             n += 1;
         }
         info!("Got {:?} after {} attempts", connected, n);
-    }
-
-    fn get_wlock(shmem: &mut SharedMem) -> WriteLockGuard<SharedState> {
-        match shmem.wlock::<SharedState>(0) {
-            Ok(v) => v,
-            Err(_) => panic!("Failed to acquire write lock !"),
-        }
-    }
-
-    fn get_rlock(shmem: &mut SharedMem) -> ReadLockGuard<SharedState> {
-        match shmem.rlock::<SharedState>(0) {
-            Ok(v) => v,
-            Err(_) => panic!("Failed to acquire write lock !"),
-        }
     }
 
     fn shared_init() {
@@ -455,11 +437,11 @@ mod tests {
         //Wait a slight bit to ensure that the test-plugin worker thread has initialised the shared mem
         ::std::thread::sleep(Duration::from_millis(500));
 
-        let mut shmem = match SharedMem::open_linked(
+        let mut shmem = match ShmemConf::new().size(4096).flink(
             std::env::temp_dir()
                 .join("wooting-test-plugin.link")
                 .as_os_str(),
-        ) {
+        ).open() {
             Ok(v) => v,
             Err(e) => {
                 println!("Error : {}", e);
@@ -474,7 +456,7 @@ mod tests {
         //Check the connected cb is called
         {
             {
-                let mut shared_state = get_wlock(&mut shmem);
+                let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
                 shared_state.device_connected = true;
             }
             wait_for_connected(5, true);
@@ -506,7 +488,7 @@ mod tests {
         //Check the cb is called with disconnected
         {
             {
-                let mut shared_state = get_wlock(&mut shmem);
+                let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
                 shared_state.device_connected = false;
             }
             wait_for_connected(5, false);
@@ -529,7 +511,7 @@ mod tests {
         let analog_key = 5;
         //Connect the device again, set a keycode to a val
         let device_id = {
-            let mut shared_state = get_wlock(&mut shmem);
+            let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             shared_state.analog_values[analog_key] = analog_val;
             shared_state.device_connected = true;
             1
@@ -632,7 +614,7 @@ mod tests {
         wooting_analog_set_keycode_mode(mode.clone() as u32);
 
         {
-            let mut shared_state = get_wlock(&mut shmem);
+            let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             shared_state.analog_values[analog_key] = 0;
         }
         ::std::thread::sleep(Duration::from_secs(1));
@@ -668,7 +650,7 @@ mod tests {
             WootingAnalogResult::Ok
         );
         {
-            let mut shared_state = get_wlock(&mut shmem);
+            let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             shared_state.device_connected = false;
         }
         ::std::thread::sleep(Duration::from_secs(1));

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -15,7 +15,6 @@ extern crate wooting_analog_common;
 extern crate wooting_analog_plugin_dev;
 
 #[cfg(test)]
-#[macro_use]
 extern crate shared_memory;
 
 //library modules

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -487,7 +487,7 @@ impl Default for AnalogSDK {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shared_memory::*;
+    use shared_memory::ShmemConf;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -509,8 +509,6 @@ mod tests {
 
         pub analog_values: [u8; 0xFF],
     }
-
-    unsafe impl SharedMemCast for SharedState {}
 
     fn shared_init() {
         env_logger::try_init_from_env(env_logger::Env::from("debug"))
@@ -548,13 +546,6 @@ mod tests {
             Err(WootingAnalogResult::NoPlugins)
         );
         assert!(!sdk.initialised)
-    }
-
-    fn get_wlock(shmem: &mut SharedMem) -> WriteLockGuard<SharedState> {
-        match shmem.wlock::<SharedState>(0) {
-            Ok(v) => v,
-            Err(_) => panic!("Failed to acquire write lock !"),
-        }
     }
 
     //    lazy_static! { static ref  }
@@ -604,11 +595,11 @@ mod tests {
         //Wait a slight bit to ensure that the test-plugin worker thread has initialised the shared mem
         ::std::thread::sleep(Duration::from_millis(500));
 
-        let mut shmem = match SharedMem::open_linked(
+        let mut shmem = match ShmemConf::new().size(4096).flink(
             std::env::temp_dir()
                 .join("wooting-test-plugin.link")
                 .as_os_str(),
-        ) {
+        ).open() {
             Ok(v) => v,
             Err(e) => {
                 println!("Error : {}", e);
@@ -641,7 +632,7 @@ mod tests {
         //Check the connected cb is called
         {
             {
-                let mut shared_state = get_wlock(&mut shmem);
+                let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
                 shared_state.device_connected = true;
             }
             wait_for_connected(&got_connected, 5, true);
@@ -655,7 +646,7 @@ mod tests {
         //Check the cb is called with disconnected
         {
             {
-                let mut shared_state = get_wlock(&mut shmem);
+                let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
                 shared_state.device_connected = false;
             }
             wait_for_connected(&got_connected, 5, false);
@@ -671,7 +662,7 @@ mod tests {
         let analog_key = 5;
         //Connect the device again, set a keycode to a val
         let device_id = {
-            let mut shared_state = get_wlock(&mut shmem);
+            let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             shared_state.analog_values[analog_key] = analog_val;
             shared_state.device_connected = true;
             1
@@ -747,7 +738,7 @@ mod tests {
         sdk().keycode_mode = KeycodeType::HID;
 
         {
-            let mut shared_state = get_wlock(&mut shmem);
+            let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             shared_state.analog_values[analog_key] = 0;
         }
         ::std::thread::sleep(Duration::from_secs(1));
@@ -763,7 +754,7 @@ mod tests {
 
         sdk().clear_device_event_cb();
         {
-            let mut shared_state = get_wlock(&mut shmem);
+            let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             shared_state.device_connected = false;
         }
         ::std::thread::sleep(Duration::from_secs(1));

--- a/wooting-analog-test-plugin/Cargo.toml
+++ b/wooting-analog-test-plugin/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 wooting-analog-plugin-dev = { path = "../wooting-analog-plugin-dev"}
-shared_memory = "^0.8"
+shared_memory = "^0.12"
 log = "^0.4"
 env_logger = "^0.8"
 

--- a/wooting-analog-test-plugin/src/lib.rs
+++ b/wooting-analog-test-plugin/src/lib.rs
@@ -44,8 +44,6 @@ pub struct SharedState {
     pub analog_values: [u8; 0xFF],
 }
 
-unsafe impl SharedMemCast for SharedState {}
-
 impl WootingAnalogTestPlugin {
     fn new() -> Self {
         if let Err(e) = env_logger::try_init() {
@@ -68,8 +66,8 @@ impl WootingAnalogTestPlugin {
 
         let worker_thread = thread::spawn(move || {
             let link_path = std::env::temp_dir().join("wooting-test-plugin.link");
-            let mut my_shmem = {
-                match SharedMem::open_linked(link_path.as_os_str()) {
+            let my_shmem = {
+                match ShmemConf::new().size(4096).flink(link_path.as_os_str()).open() {
                     Ok(v) => v,
                     Err(e) => {
                         if link_path.exists() {
@@ -79,7 +77,7 @@ impl WootingAnalogTestPlugin {
                                 error!("Could not delete old link file: {}", e);
                             }
                         }
-                        match SharedMem::create_linked(link_path.as_os_str(), LockType::Mutex, 4096)
+                        match ShmemConf::new().size(4096).flink(link_path.as_os_str()).create()
                         {
                             Ok(m) => m,
                             Err(e) => {
@@ -93,16 +91,10 @@ impl WootingAnalogTestPlugin {
                 }
             };
 
-            info!("{:?}", my_shmem.get_link_path());
+            info!("{:?}", my_shmem.get_flink_path());
 
             {
-                let mut shared_state = match my_shmem.wlock::<SharedState>(0) {
-                    Ok(v) => v,
-                    Err(_) => {
-                        error!("Test plugin Failed to acquire write lock! Stopping...");
-                        return;
-                    }
-                };
+                let shared_state = unsafe { &mut *(my_shmem.as_ptr() as *mut u8 as *mut SharedState) };
                 shared_state.vendor_id = 0x03eb;
                 shared_state.product_id = 0xFFFF;
                 shared_state.device_type = DeviceType::Keyboard;
@@ -122,13 +114,7 @@ impl WootingAnalogTestPlugin {
                 }
 
                 {
-                    let mut state = match my_shmem.wlock::<SharedState>(0) {
-                        Ok(v) => v,
-                        Err(_) => {
-                            warn!("failed to get lock");
-                            continue;
-                        }
-                    };
+                    let state = unsafe { &mut *(my_shmem.as_ptr() as *mut u8 as *mut SharedState) };
 
                     if state.dirty_device_info || t_device.lock().unwrap().is_none() {
                         state.dirty_device_info = false;
@@ -166,8 +152,6 @@ impl WootingAnalogTestPlugin {
                     }
 
                     if !state.device_connected {
-                        //make sure we drop the state so we're not holding the lock while the thread is sleeping
-                        drop(state);
                         thread::sleep(Duration::from_millis(500));
                         continue;
                     }

--- a/wooting-analog-virtual-control/Cargo.toml
+++ b/wooting-analog-virtual-control/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 wooting-analog-common = { path = "../wooting-analog-common"}
-shared_memory = "^0.8"
+shared_memory = "^0.12"
 log = "^0.4"
 iced = "^0.4"
 env_logger = "0.8"

--- a/wooting-analog-virtual-control/src/main.rs
+++ b/wooting-analog-virtual-control/src/main.rs
@@ -251,21 +251,17 @@ impl Key {
         .into()
     }
 
-    fn update(&mut self, shared_state: &mut SharedMem, value: f32) {
+    fn update(&mut self, shared_state: &mut Shmem, value: f32) {
         self.value = value;
-        match shared_state.wlock::<SharedState>(0) {
-            Ok(mut v) => {
-                v.analog_values[self.keycode as usize] = self.value as u8;
-                // info!("Updated key: {}, to {}", self.keycode, self.value);
-            }
-            Err(_) => panic!("Failed to acquire write lock !"),
-        };
+        let v = unsafe { &mut *(shared_state.as_ptr() as *mut u8 as *mut SharedState) };
+        v.analog_values[self.keycode as usize] = self.value as u8;
+        // info!("Updated key: {}, to {}", self.keycode, self.value);
     }
 }
 
 struct AppState {
     keys: Vec<Vec<Key>>,
-    shared_mem: SharedMem,
+    shared_mem: Shmem,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -278,11 +274,11 @@ impl Sandbox for AppState {
     type Message = Message;
 
     fn new() -> Self {
-        let mut shmem = match SharedMem::open_linked(
+        let shmem = match ShmemConf::new().size(4096).flink(
             std::env::temp_dir()
                 .join("wooting-test-plugin.link")
                 .as_os_str(),
-        ) {
+        ).open() {
             Ok(v) => v,
             Err(e) => {
                 info!("Error : {}", e);
@@ -290,28 +286,14 @@ impl Sandbox for AppState {
             }
         };
 
-        info!("Opened link file with info : {}", shmem);
-
-        //Make sure at least one lock exists before using it...
-        if shmem.num_locks() != 1 {
-            println!("Expected to only have 1 lock in shared mapping !");
-            panic!();
-        }
-
         //Tell the plugin that we've connected
         {
-            let mut shared_state = match shmem.wlock::<SharedState>(0) {
-                Ok(v) => v,
-                Err(_) => panic!("Failed to acquire write lock !"),
-            };
+            let shared_state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             shared_state.device_connected = true;
         }
         let mut keys = vec![];
         {
-            let state = match shmem.rlock::<SharedState>(0) {
-                Ok(v) => v,
-                Err(_) => panic!("Failed to acquire read lock !"),
-            };
+            let state = unsafe { &mut *(shmem.as_ptr() as *mut u8 as *mut SharedState) };
             for (y, items) in KEYBOARD_LAYOUT.iter().enumerate() {
                 let mut row: Vec<Key> = vec![];
                 for (x, &(name, code, width, height)) in items.iter().enumerate() {
@@ -352,10 +334,8 @@ impl Sandbox for AppState {
                     .update(&mut self.shared_mem, val);
             }
             Message::ConnectedChanged(state) => {
-                match self.shared_mem.wlock::<SharedState>(0) {
-                    Ok(mut shared_state) => shared_state.device_connected = state,
-                    Err(_) => panic!("Failed to acquire read lock !"),
-                };
+                let shared_state = unsafe { &mut *(self.shared_mem.as_ptr() as *mut u8 as *mut SharedState) };
+                shared_state.device_connected = state;
             }
         }
     }
@@ -371,9 +351,7 @@ impl Sandbox for AppState {
         }
         col.push(
             Row::new().push(Checkbox::new(
-                self.shared_mem
-                    .rlock::<SharedState>(0)
-                    .unwrap()
+                unsafe { &mut *(self.shared_mem.as_ptr() as *mut u8 as *mut SharedState) }
                     .device_connected,
                 "Device Connected",
                 Message::ConnectedChanged,
@@ -387,10 +365,7 @@ impl Sandbox for AppState {
 impl Drop for AppState {
     fn drop(&mut self) {
         //Perform cleanup
-        let mut shared_state = match self.shared_mem.wlock::<SharedState>(0) {
-            Ok(v) => v,
-            Err(_) => panic!("Failed to acquire write lock !"),
-        };
+        let shared_state = unsafe { &mut *(self.shared_mem.as_ptr() as *mut u8 as *mut SharedState) };
 
         shared_state.device_connected = false;
         shared_state.analog_values.iter_mut().for_each(|x| *x = 0);


### PR DESCRIPTION
The crate now only provides a ptr to the shared memory and no locking primitive of its own, which I think is perfectly fine for this use-case as we're only operating on plain old data.

Tested with wooting-analog-midi.