### PR TITLE
Delegate to system dll if possible

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,30 @@
+[alias]
+dist-win = [
+    "rustc",
+    "-p", "wooting-analog-sdk",
+    "--features", "ffi,dist",
+    "--release",
+    "--",
+    "-C", "link-arg=/OUT:target/release/wooting_analog_sdk_dist.dll",
+    "-C", "link-arg=/IMPLIB:target/release/wooting_analog_sdk_dist.lib",
+]
+
+dist-linux = [
+    "rustc",
+    "-p", "wooting-analog-sdk",
+    "--features", "ffi,dist",
+    "--release",
+    "--",
+    "-C", "link-arg=-Wl,-soname,./target/release/libwooting_analog_sdk_dist.so",
+    "-C", "link-arg=-Wl,-o,./target/release/libwooting_analog_sdk_dist.so",
+]
+
+dist-mac = [
+    "rustc",
+    "-p", "wooting-analog-sdk",
+    "--features", "ffi,dist",
+    "--release",
+    "--",
+    "-C", "link-arg=-Wl,-install_name,./target/release/libwooting_analog_sdk_dist.dylib",
+    "-C", "link-arg=-Wl,-o,./target/release/libwooting_analog_sdk_dist.dylib",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ rpath = true
 rpath = true
 
 [workspace]
-resolver = "2"
-
+default-members = ["wooting-analog-sdk"]
 members = [
     "wooting-analog-virtual-control",
     "wooting-analog-sdk",
-    "wooting-analog-sdk-updater"
+    "wooting-analog-sdk-updater",
 ]
+resolver = "2"

--- a/includes/wooting-analog-sdk.h
+++ b/includes/wooting-analog-sdk.h
@@ -97,6 +97,9 @@ int wooting_analog_initialise(void);
 /// there may be some breaking changes that have been made so the SDK should not be attempted to be used
 int wooting_analog_version(void);
 
+/// SDK version as a static null-terminated string in SemVer format.
+const char *wooting_analog_version_semver(void);
+
 /// Returns a bool indicating if the Analog SDK has been initialised
 bool wooting_analog_is_initialised(void);
 
@@ -233,6 +236,8 @@ int wooting_analog_read_full_buffer_device(unsigned short *code_buffer,
                                            float *analog_buffer,
                                            unsigned int len,
                                            WootingAnalog_DeviceID device_id);
+
+bool wooting_analog_using_sys(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/wooting-analog-sdk/Cargo.toml
+++ b/wooting-analog-sdk/Cargo.toml
@@ -13,6 +13,7 @@ keywords = [ "wooting", "keyboard", "analog", "sdk" ]
 
 [features]
 ffi = []
+local_dll = []
 
 [dependencies]
 log = "0.4"

--- a/wooting-analog-sdk/Cargo.toml
+++ b/wooting-analog-sdk/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [ "wooting", "keyboard", "analog", "sdk" ]
 
 [features]
 ffi = []
-local_dll = []
+dist = []
 
 [dependencies]
 log = "0.4"

--- a/wooting-analog-sdk/build.rs
+++ b/wooting-analog-sdk/build.rs
@@ -1,22 +1,36 @@
-use std::{fs, io, env, path::PathBuf};
-
-const TEST_PLUGIN_DIR: &str = "test_c_plugin";
-
-fn main() -> io::Result<()> {
-    println!("Building Test C Plugin");
-
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let source_dir = manifest_dir.join(TEST_PLUGIN_DIR);
-    let out_dir = source_dir.join("build");
-
-    fs::create_dir_all(out_dir)?;
-    
-    cmake::Config::new(&source_dir)
-        .no_build_target(true)
-        .out_dir(&source_dir)
-        .always_configure(false)
-        .profile("Debug")
-        .build();
+fn main() -> std::io::Result<()> {
+    #[test]
+    build_test_plugin()?;
 
     Ok(())
+}
+
+// TODO: rework this when we get to unit/integration testing
+// this fails to compile if you `cargo test` without cmake being installed on the system
+#[test]
+mod test {
+    use std::{env, fs, io, path::PathBuf};
+
+    const TEST_PLUGIN_DIR: &str = "test_c_plugin";
+
+    fn build_test_plugin() -> io::Result<()> {
+        println!("Building Test C Plugin");
+
+        let manifest_dir = PathBuf::from(
+            env::var("CARGO_MANIFEST_DIR").expect("crate should always have a manifest directory"),
+        );
+        let source_dir = manifest_dir.join(TEST_PLUGIN_DIR);
+        let out_dir = source_dir.join("build");
+
+        fs::create_dir_all(out_dir)?;
+
+        cmake::Config::new(&source_dir)
+            .no_build_target(true)
+            .out_dir(&source_dir)
+            .always_configure(false)
+            .profile("Debug")
+            .build();
+
+        Ok(())
+    }
 }

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -1,17 +1,19 @@
+#[cfg(feature = "dist")]
+mod delegate_sys;
+
 use crate::{
     DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeycodeType, SDKResult,
     WootingAnalogResult, sdk::*,
 };
-use libloading::{self, Symbol};
 use log::{error, trace};
 use num_traits::FromPrimitive;
 use std::cell::RefCell;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort};
-use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
 use std::{env, panic, slice};
+use delegate_sys::USE_SYS_DLL;
 
-pub static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
+static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
     // Initialising logger with default "off".
     // If the library user wants logging, they can set the RUST_LOG environment variable, e.g. to "info".
     // TODO: Consider using file logging or allowing the user to set a custom log callback.
@@ -24,84 +26,6 @@ pub static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
     Mutex::new(AnalogSDK::new())
 });
 
-fn find_dll_in_path() -> Option<PathBuf> {
-    if let Ok(path_var) = std::env::var("PATH") {
-        for dir in std::env::split_paths(&path_var) {
-            if dir.ends_with("wooting-analog-sdk") {
-                return Some(dir);
-            }
-        }
-    }
-    None
-}
-
-#[cfg(feature = "dist")]
-static LIB: LazyLock<Option<libloading::Library>> = LazyLock::new(|| {
-    // #[cfg(target_arch = "x86")]
-    // let lib_path = concat!("wooting_analog_sdk", "32");
-
-    // #[cfg(all(unix, not(target_os = "macos")))]
-    // let lib_path = concat!("lib", "wooting_analog_sdk", ".so");
-    // #[cfg(all(unix, target_os = "macos"))]
-    // let lib_path = concat!("lib", "wooting_analog_sdk", ".dylib");
-    // #[cfg(windows)]
-    // let lib_path = "C:/Program Files/wooting-analog-sdk/wooting_analog_sdk";
-
-    // pretty much windows only, not certain on other platforms if it is the dir with the same name
-    let lib_path =
-        find_dll_in_path().map(|p| p.join(libloading::library_filename("wooting_analog_sdk")))?;
-
-    unsafe {
-        //Attempt to load the library, if it fails print the error and discard the error
-        libloading::Library::new(&lib_path)
-            .map_err(|e| {
-                println!("Unable to load library: {:?}\nErr: {}", lib_path, e);
-            })
-            .ok()
-    }
-});
-
-// TODO: use crate version
-const SDK_VERSION: i32 = 0;
-
-#[cfg(feature = "dist")]
-static USE_SYS_DLL: LazyLock<bool> = LazyLock::new(|| {
-    try_system_dll()
-        // TODO: clean error message
-        .inspect_err(|e| eprintln!("failed to call sys: {e:?}"))
-        .is_ok()
-});
-
-#[cfg(feature = "dist")]
-fn try_system_dll() -> Result<(), WootingAnalogResult> {
-    if LIB.is_none() {
-        return Err(WootingAnalogResult::DLLNotFound);
-    }
-
-    static VERSION_FN: LazyLock<Option<Symbol<extern "C" fn() -> i32>>> = LazyLock::new(|| {
-        LIB.as_ref().and_then(|lib| unsafe {
-            //Get func, print and discard error as we don't need it again
-            lib.get(b"wooting_analog_version")
-                .map_err(|e| {
-                    println!("Could not find symbol 'wooting_analog_version', {}", e);
-                })
-                .ok()
-        })
-    });
-
-    match VERSION_FN.as_deref() {
-        Some(version_fn) => {
-            let version = version_fn();
-
-            if version == SDK_VERSION {
-                Ok(())
-            } else {
-                Err(WootingAnalogResult::IncompatibleVersion)
-            }
-        }
-        _ => Err(WootingAnalogResult::FunctionNotFound),
-    }
-}
 
 /// Initialises the Analog SDK, this needs to be successfully called before any other functions
 /// of the SDK can be called
@@ -111,44 +35,9 @@ fn try_system_dll() -> Result<(), WootingAnalogResult> {
 /// * `NoPlugins`: Meaning that either no plugins were found or some were found but none were successfully initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_initialise() -> c_int {
-    // match try_system_dll() {
-    //     Ok(()) => {
-    //         static INIT_FN: LazyLock<Option<Symbol<extern "C" fn() -> i32>>> = LazyLock::new(|| {
-    //             LIB.as_ref().and_then(|lib| unsafe {
-    //                 //Get func, print and discard error as we don't need it again
-    //                 lib.get(b"wooting_analog_initialise").map_err(|e| {
-    //                     println!("Could not find symbol 'wooting_analog_initialise', {}", e);
-    //                 }).ok()
-    //             })
-    //         });
-
-    //         return match INIT_FN.as_deref() {
-    //             Some(f) => f(),
-    //             _ => WootingAnalogResult::FunctionNotFound.into()
-    //         }
-    //     },
-    //     Err(e) => println!("failed to call sys: {e:?}")
-    // }
-
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn() -> i32;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_initialise")
-                    .map_err(|e| {
-                        println!("Could not find symbol 'wooting_analog_initialise', {}", e);
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_initialise();
     }
 
     let result = panic::catch_unwind(|| {
@@ -171,26 +60,7 @@ pub extern "C" fn wooting_analog_initialise() -> c_int {
 pub extern "C" fn wooting_analog_version() -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn() -> c_int;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_version")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_version', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_version();
     }
 
     env!("CARGO_PKG_VERSION")
@@ -198,7 +68,7 @@ pub extern "C" fn wooting_analog_version() -> c_int {
         .collect::<Vec<&str>>()
         .first()
         .and_then(|v| v.parse().ok())
-        .unwrap()
+        .expect("crate must have correct package semver format")
 }
 
 /// Returns a bool indicating if the Analog SDK has been initialised
@@ -206,26 +76,7 @@ pub extern "C" fn wooting_analog_version() -> c_int {
 pub extern "C" fn wooting_analog_is_initialised() -> bool {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn() -> bool;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_is_initialised")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_is_initialised', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_is_initialised();
     }
 
     ANALOG_SDK.lock().unwrap().initialised
@@ -238,23 +89,7 @@ pub extern "C" fn wooting_analog_is_initialised() -> bool {
 pub extern "C" fn wooting_analog_uninitialise() -> WootingAnalogResult {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn() -> WootingAnalogResult;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_uninitialise")
-                    .map_err(|e| {
-                        println!("Could not find symbol 'wooting_analog_uninitialise', {}", e);
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(),
-            _ => WootingAnalogResult::FunctionNotFound,
-        };
+        return delegate_sys::wooting_analog_uninitialise();
     }
 
     trace!("wooting_analog_uninitialise called");
@@ -296,26 +131,7 @@ pub extern "C" fn wooting_analog_uninitialise() -> WootingAnalogResult {
 pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn(c_uint) -> WootingAnalogResult;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_set_keycode_mode")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_set_keycode_mode', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(mode),
-            _ => WootingAnalogResult::FunctionNotFound,
-        };
+        return delegate_sys::wooting_analog_set_keycode_mode(mode);
     }
 
     if !ANALOG_SDK.lock().unwrap().initialised {
@@ -363,23 +179,7 @@ pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalog
 pub extern "C" fn wooting_analog_read_analog(code: c_ushort) -> c_float {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn(c_ushort) -> c_float;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_read_analog")
-                    .map_err(|e| {
-                        println!("Could not find symbol 'wooting_analog_read_analog', {}", e);
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(code),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_read_analog(code);
     }
 
     wooting_analog_read_analog_device(code, 0)
@@ -404,26 +204,7 @@ pub extern "C" fn wooting_analog_read_analog_device(
 ) -> c_float {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn(c_ushort, DeviceID) -> c_float;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_read_analog_device")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_read_analog_device', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(code, device_id),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_read_analog_device(code, device_id);
     }
 
     ANALOG_SDK
@@ -449,28 +230,7 @@ pub extern "C" fn wooting_analog_set_device_event_cb(
 ) -> WootingAnalogResult {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn(
-            cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI),
-        ) -> WootingAnalogResult;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_set_device_event_cb")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_set_device_event_cb', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(cb),
-            _ => WootingAnalogResult::FunctionNotFound,
-        };
+        return delegate_sys::wooting_analog_set_device_event_cb(cb);
     }
 
     ANALOG_SDK
@@ -498,26 +258,7 @@ pub extern "C" fn wooting_analog_set_device_event_cb(
 pub extern "C" fn wooting_analog_clear_device_event_cb() -> WootingAnalogResult {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn() -> WootingAnalogResult;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_clear_device_event_cb")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_clear_device_event_cb', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(),
-            _ => WootingAnalogResult::FunctionNotFound,
-        };
+        return delegate_sys::wooting_analog_clear_device_event_cb();
     }
 
     ANALOG_SDK.lock().unwrap().clear_device_event_cb().into()
@@ -541,26 +282,7 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn(*mut *mut DeviceInfo_FFI, c_uint) -> c_int;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_get_connected_devices_info")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_get_connected_devices_info', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(buffer, len),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_get_connected_devices_info(buffer, len);
     }
 
     let result: SDKResult<Vec<DeviceInfo>> = ANALOG_SDK.lock().unwrap().get_device_info();
@@ -625,26 +347,7 @@ pub extern "C" fn wooting_analog_read_full_buffer(
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint) -> c_int;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_read_full_buffer")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_read_full_buffer', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(code_buffer, analog_buffer, len),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_read_full_buffer_device(code_buffer, analog_buffer, len, 0);
     }
 
     wooting_analog_read_full_buffer_device(code_buffer, analog_buffer, len, 0)
@@ -675,33 +378,13 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint, DeviceID) -> i32;
-
-        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-            LIB.as_ref().and_then(|lib| unsafe {
-                //Get func, print and discard error as we don't need it again
-                lib.get(b"wooting_analog_read_full_buffer_device")
-                    .map_err(|e| {
-                        println!(
-                            "Could not find symbol 'wooting_analog_read_full_buffer_device', {}",
-                            e
-                        );
-                    })
-                    .ok()
-            })
-        });
-
-        return match FN.as_deref() {
-            Some(f) => f(code_buffer, analog_buffer, len, device_id),
-            _ => WootingAnalogResult::FunctionNotFound.into(),
-        };
+        return delegate_sys::wooting_analog_read_full_buffer_device(
+            code_buffer,
+            analog_buffer,
+            len,
+            device_id,
+        );
     }
-
-    #[cfg(not(feature = "dist"))]
-    println!("hi from system dll");
-
-    #[cfg(feature = "dist")]
-    println!("called normal from local");
 
     let codes = unsafe {
         assert!(!code_buffer.is_null());
@@ -737,188 +420,4 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
         }
         Err(e) => e as c_int,
     }
-
-    // match *DLL_LOC {
-    //     DllLocation::System => {
-    //         println!("went through system dll");
-
-    //         type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint, DeviceID) -> i32;
-
-    //         static READ_FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
-    //             LIB.as_ref().and_then(|lib| unsafe {
-    //                 //Get func, print and discard error as we don't need it again
-    //                 lib.get(b"wooting_analog_read_full_buffer_device").map_err(|e| {
-    //                     println!("Could not find symbol 'wooting_analog_read_full_buffer_device', {}", e);
-    //                 }).ok()
-    //             })
-    //         });
-
-    //         match READ_FN.as_deref() {
-    //             Some(f) => f(code_buffer, analog_buffer, len, device_id),
-    //             _ => WootingAnalogResult::FunctionNotFound.into(),
-    //         }
-    //     }
-    //     DllLocation::Local => {
-    //         println!("went through self");
-
-    //         let codes = unsafe {
-    //             assert!(!code_buffer.is_null());
-
-    //             slice::from_raw_parts_mut(code_buffer, len as usize)
-    //         };
-
-    //         let analog = unsafe {
-    //             assert!(!analog_buffer.is_null());
-
-    //             slice::from_raw_parts_mut(analog_buffer, len as usize)
-    //         };
-
-    //         match ANALOG_SDK
-    //             .lock()
-    //             .unwrap()
-    //             .read_full_buffer(len as usize, device_id)
-    //             .0
-    //         {
-    //             Ok(analog_data) => {
-    //                 //Fill up given slices
-    //                 let mut count: usize = 0;
-    //                 for (code, val) in analog_data.iter() {
-    //                     if count >= codes.len() {
-    //                         break;
-    //                     }
-
-    //                     codes[count] = *code;
-    //                     analog[count] = *val;
-    //                     count += 1;
-    //                 }
-    //                 count as c_int
-    //             }
-    //             Err(e) => e as c_int,
-    //         }
-    //     }
-    // }
-
-    // if USE_SYS_DLL.load(Ordering::Relaxed) {
-    //     static READ_FN: LazyLock<Option<Symbol<extern "C" fn(
-    //         *mut c_ushort,
-    //         *mut c_float,
-    //         c_uint,
-    //         DeviceID
-    //     ) -> i32>>> = LazyLock::new(|| {
-    //         LIB.as_ref().and_then(|lib| unsafe {
-    //             //Get func, print and discard error as we don't need it again
-    //             lib.get(b"wooting_analog_read_full_buffer_device").map_err(|e| {
-    //                 println!("Could not find symbol 'wooting_analog_read_full_buffer_device', {}", e);
-    //             }).ok()
-    //         })
-    //     });
-
-    //     return match READ_FN.as_deref() {
-    //         Some(f) => f(code_buffer, analog_buffer, len, device_id),
-    //         _ => WootingAnalogResult::FunctionNotFound.into()
-    //     }
-    // }
-
-    // let codes = unsafe {
-    //     assert!(!code_buffer.is_null());
-
-    //     slice::from_raw_parts_mut(code_buffer, len as usize)
-    // };
-
-    // let analog = unsafe {
-    //     assert!(!analog_buffer.is_null());
-
-    //     slice::from_raw_parts_mut(analog_buffer, len as usize)
-    // };
-
-    // println!("went through self");
-
-    // match ANALOG_SDK
-    //     .lock()
-    //     .unwrap()
-    //     .read_full_buffer(len as usize, device_id)
-    //     .0
-    // {
-    //     Ok(analog_data) => {
-    //         //Fill up given slices
-    //         let mut count: usize = 0;
-    //         for (code, val) in analog_data.iter() {
-    //             if count >= codes.len() {
-    //                 break;
-    //             }
-
-    //             codes[count] = *code;
-    //             analog[count] = *val;
-    //             count += 1;
-    //         }
-    //         count as c_int
-    //     }
-    //     Err(e) => e as c_int,
-    // }
-
-    // type FnPtr = unsafe extern "C" fn(code_buffer: *mut c_ushort,
-    //     analog_buffer: *mut c_float,
-    //     len: c_uint,
-    //     device_id: DeviceID) -> c_int;
-
-    // if LIB.is_some() {
-    //     if "wooting_analog_read_full_buffer_device" != "wooting_analog_version" && wooting_analog_version() >= 0 && wooting_analog_version() != 0 {
-    //         println!("Cannot access Wooting Analog SDK function as this wrapper is for SDK major version {}, whereas the SDK has major version {}", 0, wooting_analog_version());
-    //         return WootingAnalogResult::IncompatibleVersion.into()
-    //     }
-
-    //         static FUNC: LazyLock<Option<libloading::Symbol<'static, FnPtr>>> = LazyLock::new(|| {
-    //             LIB.as_ref().and_then(|lib| unsafe {
-    //                 //Get func, print and discard error as we don't need it again
-    //                 lib.get(b"wooting_analog_read_full_buffer_device").map_err(|_e| {
-    //                     println!("Could not find symbol '{}', {}", stringify!($fn_names), _e);
-    //                 }).ok()
-    //             })
-    //         });
-
-    //     match FUNC.as_deref() {
-    //         Some(f) => unsafe { f(code_buffer,
-    //     analog_buffer,
-    //     len,
-    //     device_id) },
-    //         _ => WootingAnalogResult::FunctionNotFound.into()
-    //     }
-    // } else {
-    //     let codes = unsafe {
-    //         assert!(!code_buffer.is_null());
-
-    //         slice::from_raw_parts_mut(code_buffer, len as usize)
-    //     };
-
-    //     let analog = unsafe {
-    //         assert!(!analog_buffer.is_null());
-
-    //         slice::from_raw_parts_mut(analog_buffer, len as usize)
-    //     };
-
-    //     println!("went through self");
-
-    //     match ANALOG_SDK
-    //         .lock()
-    //         .unwrap()
-    //         .read_full_buffer(len as usize, device_id)
-    //         .0
-    //     {
-    //         Ok(analog_data) => {
-    //             //Fill up given slices
-    //             let mut count: usize = 0;
-    //             for (code, val) in analog_data.iter() {
-    //                 if count >= codes.len() {
-    //                     break;
-    //                 }
-
-    //                 codes[count] = *code;
-    //                 analog[count] = *val;
-    //                 count += 1;
-    //             }
-    //             count as c_int
-    //         }
-    //         Err(e) => e as c_int,
-    //     }
-    // }
 }

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -2,7 +2,6 @@ use crate::{
     DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeycodeType, SDKResult,
     WootingAnalogResult, sdk::*,
 };
-use ffi_support::FfiStr;
 use libloading::{self, Symbol};
 use log::{error, trace};
 use num_traits::FromPrimitive;
@@ -36,7 +35,7 @@ fn find_dll_in_path() -> Option<PathBuf> {
     None
 }
 
-#[cfg(feature = "local_dll")]
+#[cfg(feature = "dist")]
 static LIB: LazyLock<Option<libloading::Library>> = LazyLock::new(|| {
     // #[cfg(target_arch = "x86")]
     // let lib_path = concat!("wooting_analog_sdk", "32");
@@ -65,14 +64,15 @@ static LIB: LazyLock<Option<libloading::Library>> = LazyLock::new(|| {
 // TODO: use crate version
 const SDK_VERSION: i32 = 0;
 
-#[cfg(feature = "local_dll")]
+#[cfg(feature = "dist")]
 static USE_SYS_DLL: LazyLock<bool> = LazyLock::new(|| {
     try_system_dll()
-        .map_err(|e| println!("failed to call sys: {e:?}"))
+        // TODO: clean error message
+        .inspect_err(|e| eprintln!("failed to call sys: {e:?}"))
         .is_ok()
 });
 
-#[cfg(feature = "local_dll")]
+#[cfg(feature = "dist")]
 fn try_system_dll() -> Result<(), WootingAnalogResult> {
     if LIB.is_none() {
         return Err(WootingAnalogResult::DLLNotFound);
@@ -130,7 +130,7 @@ pub extern "C" fn wooting_analog_initialise() -> c_int {
     //     Err(e) => println!("failed to call sys: {e:?}")
     // }
 
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn() -> i32;
 
@@ -169,7 +169,7 @@ pub extern "C" fn wooting_analog_initialise() -> c_int {
 /// there may be some breaking changes that have been made so the SDK should not be attempted to be used
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_version() -> c_int {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn() -> c_int;
 
@@ -204,7 +204,7 @@ pub extern "C" fn wooting_analog_version() -> c_int {
 /// Returns a bool indicating if the Analog SDK has been initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_is_initialised() -> bool {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn() -> bool;
 
@@ -236,7 +236,7 @@ pub extern "C" fn wooting_analog_is_initialised() -> bool {
 /// * `Ok`: Indicates that the SDK was successfully uninitialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_uninitialise() -> WootingAnalogResult {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn() -> WootingAnalogResult;
 
@@ -294,7 +294,7 @@ pub extern "C" fn wooting_analog_uninitialise() -> WootingAnalogResult {
 /// * `UnInitialized`: The SDK is not initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn(c_uint) -> WootingAnalogResult;
 
@@ -361,7 +361,7 @@ pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalog
 /// * `WootingAnalogResult::NoDevices`: There are no connected devices
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_read_analog(code: c_ushort) -> c_float {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn(c_ushort) -> c_float;
 
@@ -402,7 +402,7 @@ pub extern "C" fn wooting_analog_read_analog_device(
     code: c_ushort,
     device_id: DeviceID,
 ) -> c_float {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn(c_ushort, DeviceID) -> c_float;
 
@@ -447,7 +447,7 @@ pub extern "C" fn wooting_analog_read_analog_device(
 pub extern "C" fn wooting_analog_set_device_event_cb(
     cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI),
 ) -> WootingAnalogResult {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn(
             cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI),
@@ -496,7 +496,7 @@ pub extern "C" fn wooting_analog_set_device_event_cb(
 /// * `UnInitialized`: The SDK is not initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_clear_device_event_cb() -> WootingAnalogResult {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn() -> WootingAnalogResult;
 
@@ -539,7 +539,7 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
     buffer: *mut *mut DeviceInfo_FFI,
     len: c_uint,
 ) -> c_int {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn(*mut *mut DeviceInfo_FFI, c_uint) -> c_int;
 
@@ -623,7 +623,7 @@ pub extern "C" fn wooting_analog_read_full_buffer(
     analog_buffer: *mut c_float,
     len: c_uint,
 ) -> c_int {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint) -> c_int;
 
@@ -673,7 +673,7 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
     len: c_uint,
     device_id: DeviceID,
 ) -> c_int {
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint, DeviceID) -> i32;
 
@@ -697,10 +697,10 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
         };
     }
 
-    #[cfg(not(feature = "local_dll"))]
+    #[cfg(not(feature = "dist"))]
     println!("hi from system dll");
 
-    #[cfg(feature = "local_dll")]
+    #[cfg(feature = "dist")]
     println!("called normal from local");
 
     let codes = unsafe {

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -438,3 +438,12 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
         Err(e) => e as c_int,
     }
 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wooting_analog_using_sys() -> bool {
+    #[cfg(feature = "dist")]
+    { *USE_SYS_DLL }
+
+    #[cfg(not(feature = "dist"))]
+    { true }
+}

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -11,6 +11,7 @@ use std::cell::RefCell;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort};
 use std::sync::{LazyLock, Mutex};
 use std::{env, panic, slice};
+#[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
 
 static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -5,14 +5,14 @@ use crate::{
     DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeycodeType, SDKResult,
     WootingAnalogResult, sdk::*,
 };
+#[cfg(feature = "dist")]
+use delegate_sys::USE_SYS_DLL;
 use log::{error, trace};
 use num_traits::FromPrimitive;
 use std::cell::RefCell;
-use std::os::raw::{c_float, c_int, c_uint, c_ushort};
+use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};
 use std::sync::{LazyLock, Mutex};
 use std::{env, panic, slice};
-#[cfg(feature = "dist")]
-use delegate_sys::USE_SYS_DLL;
 
 static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
     // Initialising logger with default "off".
@@ -26,7 +26,6 @@ static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
 
     Mutex::new(AnalogSDK::new())
 });
-
 
 /// Initialises the Analog SDK, this needs to be successfully called before any other functions
 /// of the SDK can be called
@@ -70,6 +69,18 @@ pub extern "C" fn wooting_analog_version() -> c_int {
         .first()
         .and_then(|v| v.parse().ok())
         .expect("crate must have correct package semver format")
+}
+
+/// SDK version as a static null-terminated string in SemVer format.
+#[unsafe(no_mangle)]
+pub extern "C" fn wooting_analog_version_semver() -> *const c_char {
+    #[cfg(feature = "dist")]
+    if *USE_SYS_DLL {
+        return delegate_sys::wooting_analog_version_semver();
+    }
+
+    static VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
+    VERSION.as_ptr() as *const c_char
 }
 
 /// Returns a bool indicating if the Analog SDK has been initialised
@@ -348,7 +359,12 @@ pub extern "C" fn wooting_analog_read_full_buffer(
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_full_buffer_device(code_buffer, analog_buffer, len, 0);
+        return delegate_sys::wooting_analog_read_full_buffer_device(
+            code_buffer,
+            analog_buffer,
+            len,
+            0,
+        );
     }
 
     wooting_analog_read_full_buffer_device(code_buffer, analog_buffer, len, 0)

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -3,12 +3,14 @@ use crate::{
     WootingAnalogResult, sdk::*,
 };
 use ffi_support::FfiStr;
+use libloading::{self, Symbol};
 use log::{error, trace};
 use num_traits::FromPrimitive;
 use std::cell::RefCell;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort};
+use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
-use std::{panic, slice};
+use std::{env, panic, slice};
 
 pub static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
     // Initialising logger with default "off".
@@ -23,6 +25,84 @@ pub static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
     Mutex::new(AnalogSDK::new())
 });
 
+fn find_dll_in_path() -> Option<PathBuf> {
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            if dir.ends_with("wooting-analog-sdk") {
+                return Some(dir);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(feature = "local_dll")]
+static LIB: LazyLock<Option<libloading::Library>> = LazyLock::new(|| {
+    // #[cfg(target_arch = "x86")]
+    // let lib_path = concat!("wooting_analog_sdk", "32");
+
+    // #[cfg(all(unix, not(target_os = "macos")))]
+    // let lib_path = concat!("lib", "wooting_analog_sdk", ".so");
+    // #[cfg(all(unix, target_os = "macos"))]
+    // let lib_path = concat!("lib", "wooting_analog_sdk", ".dylib");
+    // #[cfg(windows)]
+    // let lib_path = "C:/Program Files/wooting-analog-sdk/wooting_analog_sdk";
+
+    // pretty much windows only, not certain on other platforms if it is the dir with the same name
+    let lib_path =
+        find_dll_in_path().map(|p| p.join(libloading::library_filename("wooting_analog_sdk")))?;
+
+    unsafe {
+        //Attempt to load the library, if it fails print the error and discard the error
+        libloading::Library::new(&lib_path)
+            .map_err(|e| {
+                println!("Unable to load library: {:?}\nErr: {}", lib_path, e);
+            })
+            .ok()
+    }
+});
+
+// TODO: use crate version
+const SDK_VERSION: i32 = 0;
+
+#[cfg(feature = "local_dll")]
+static USE_SYS_DLL: LazyLock<bool> = LazyLock::new(|| {
+    try_system_dll()
+        .map_err(|e| println!("failed to call sys: {e:?}"))
+        .is_ok()
+});
+
+#[cfg(feature = "local_dll")]
+fn try_system_dll() -> Result<(), WootingAnalogResult> {
+    if LIB.is_none() {
+        return Err(WootingAnalogResult::DLLNotFound);
+    }
+
+    static VERSION_FN: LazyLock<Option<Symbol<extern "C" fn() -> i32>>> = LazyLock::new(|| {
+        LIB.as_ref().and_then(|lib| unsafe {
+            //Get func, print and discard error as we don't need it again
+            lib.get(b"wooting_analog_version")
+                .map_err(|e| {
+                    println!("Could not find symbol 'wooting_analog_version', {}", e);
+                })
+                .ok()
+        })
+    });
+
+    match VERSION_FN.as_deref() {
+        Some(version_fn) => {
+            let version = version_fn();
+
+            if version == SDK_VERSION {
+                Ok(())
+            } else {
+                Err(WootingAnalogResult::IncompatibleVersion)
+            }
+        }
+        _ => Err(WootingAnalogResult::FunctionNotFound),
+    }
+}
+
 /// Initialises the Analog SDK, this needs to be successfully called before any other functions
 /// of the SDK can be called
 ///
@@ -31,6 +111,46 @@ pub static ANALOG_SDK: LazyLock<Mutex<AnalogSDK>> = LazyLock::new(|| {
 /// * `NoPlugins`: Meaning that either no plugins were found or some were found but none were successfully initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_initialise() -> c_int {
+    // match try_system_dll() {
+    //     Ok(()) => {
+    //         static INIT_FN: LazyLock<Option<Symbol<extern "C" fn() -> i32>>> = LazyLock::new(|| {
+    //             LIB.as_ref().and_then(|lib| unsafe {
+    //                 //Get func, print and discard error as we don't need it again
+    //                 lib.get(b"wooting_analog_initialise").map_err(|e| {
+    //                     println!("Could not find symbol 'wooting_analog_initialise', {}", e);
+    //                 }).ok()
+    //             })
+    //         });
+
+    //         return match INIT_FN.as_deref() {
+    //             Some(f) => f(),
+    //             _ => WootingAnalogResult::FunctionNotFound.into()
+    //         }
+    //     },
+    //     Err(e) => println!("failed to call sys: {e:?}")
+    // }
+
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn() -> i32;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_initialise")
+                    .map_err(|e| {
+                        println!("Could not find symbol 'wooting_analog_initialise', {}", e);
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
     let result = panic::catch_unwind(|| {
         trace!("wooting_analog_initialise called");
         ANALOG_SDK.lock().unwrap().initialise().into()
@@ -49,6 +169,30 @@ pub extern "C" fn wooting_analog_initialise() -> c_int {
 /// there may be some breaking changes that have been made so the SDK should not be attempted to be used
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_version() -> c_int {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn() -> c_int;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_version")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_version', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
     env!("CARGO_PKG_VERSION")
         .split('.')
         .collect::<Vec<&str>>()
@@ -60,6 +204,30 @@ pub extern "C" fn wooting_analog_version() -> c_int {
 /// Returns a bool indicating if the Analog SDK has been initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_is_initialised() -> bool {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn() -> bool;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_is_initialised")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_is_initialised', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
     ANALOG_SDK.lock().unwrap().initialised
 }
 
@@ -68,6 +236,27 @@ pub extern "C" fn wooting_analog_is_initialised() -> bool {
 /// * `Ok`: Indicates that the SDK was successfully uninitialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_uninitialise() -> WootingAnalogResult {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn() -> WootingAnalogResult;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_uninitialise")
+                    .map_err(|e| {
+                        println!("Could not find symbol 'wooting_analog_uninitialise', {}", e);
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(),
+            _ => WootingAnalogResult::FunctionNotFound,
+        };
+    }
+
     trace!("wooting_analog_uninitialise called");
     let result = panic::catch_unwind(|| {
         //Drop the memory that was being kept for the connected devices info call
@@ -105,6 +294,30 @@ pub extern "C" fn wooting_analog_uninitialise() -> WootingAnalogResult {
 /// * `UnInitialized`: The SDK is not initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn(c_uint) -> WootingAnalogResult;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_set_keycode_mode")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_set_keycode_mode', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(mode),
+            _ => WootingAnalogResult::FunctionNotFound,
+        };
+    }
+
     if !ANALOG_SDK.lock().unwrap().initialised {
         return WootingAnalogResult::UnInitialized;
     }
@@ -148,6 +361,27 @@ pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalog
 /// * `WootingAnalogResult::NoDevices`: There are no connected devices
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_read_analog(code: c_ushort) -> c_float {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn(c_ushort) -> c_float;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_read_analog")
+                    .map_err(|e| {
+                        println!("Could not find symbol 'wooting_analog_read_analog', {}", e);
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(code),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
     wooting_analog_read_analog_device(code, 0)
 }
 
@@ -168,6 +402,30 @@ pub extern "C" fn wooting_analog_read_analog_device(
     code: c_ushort,
     device_id: DeviceID,
 ) -> c_float {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn(c_ushort, DeviceID) -> c_float;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_read_analog_device")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_read_analog_device', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(code, device_id),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
     ANALOG_SDK
         .lock()
         .unwrap()
@@ -189,6 +447,32 @@ pub extern "C" fn wooting_analog_read_analog_device(
 pub extern "C" fn wooting_analog_set_device_event_cb(
     cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI),
 ) -> WootingAnalogResult {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn(
+            cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI),
+        ) -> WootingAnalogResult;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_set_device_event_cb")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_set_device_event_cb', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(cb),
+            _ => WootingAnalogResult::FunctionNotFound,
+        };
+    }
+
     ANALOG_SDK
         .lock()
         .unwrap()
@@ -212,6 +496,30 @@ pub extern "C" fn wooting_analog_set_device_event_cb(
 /// * `UnInitialized`: The SDK is not initialised
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_clear_device_event_cb() -> WootingAnalogResult {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn() -> WootingAnalogResult;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_clear_device_event_cb")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_clear_device_event_cb', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(),
+            _ => WootingAnalogResult::FunctionNotFound,
+        };
+    }
+
     ANALOG_SDK.lock().unwrap().clear_device_event_cb().into()
 }
 
@@ -231,6 +539,30 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
     buffer: *mut *mut DeviceInfo_FFI,
     len: c_uint,
 ) -> c_int {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn(*mut *mut DeviceInfo_FFI, c_uint) -> c_int;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_get_connected_devices_info")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_get_connected_devices_info', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(buffer, len),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
     let result: SDKResult<Vec<DeviceInfo>> = ANALOG_SDK.lock().unwrap().get_device_info();
     match result.0 {
         Ok(mut devices) => {
@@ -291,6 +623,30 @@ pub extern "C" fn wooting_analog_read_full_buffer(
     analog_buffer: *mut c_float,
     len: c_uint,
 ) -> c_int {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint) -> c_int;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_read_full_buffer")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_read_full_buffer', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(code_buffer, analog_buffer, len),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
     wooting_analog_read_full_buffer_device(code_buffer, analog_buffer, len, 0)
 }
 
@@ -317,6 +673,36 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
     len: c_uint,
     device_id: DeviceID,
 ) -> c_int {
+    #[cfg(feature = "local_dll")]
+    if *USE_SYS_DLL {
+        type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint, DeviceID) -> i32;
+
+        static FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+            LIB.as_ref().and_then(|lib| unsafe {
+                //Get func, print and discard error as we don't need it again
+                lib.get(b"wooting_analog_read_full_buffer_device")
+                    .map_err(|e| {
+                        println!(
+                            "Could not find symbol 'wooting_analog_read_full_buffer_device', {}",
+                            e
+                        );
+                    })
+                    .ok()
+            })
+        });
+
+        return match FN.as_deref() {
+            Some(f) => f(code_buffer, analog_buffer, len, device_id),
+            _ => WootingAnalogResult::FunctionNotFound.into(),
+        };
+    }
+
+    #[cfg(not(feature = "local_dll"))]
+    println!("hi from system dll");
+
+    #[cfg(feature = "local_dll")]
+    println!("called normal from local");
+
     let codes = unsafe {
         assert!(!code_buffer.is_null());
 
@@ -351,4 +737,188 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
         }
         Err(e) => e as c_int,
     }
+
+    // match *DLL_LOC {
+    //     DllLocation::System => {
+    //         println!("went through system dll");
+
+    //         type FnPtr = extern "C" fn(*mut c_ushort, *mut c_float, c_uint, DeviceID) -> i32;
+
+    //         static READ_FN: LazyLock<Option<Symbol<FnPtr>>> = LazyLock::new(|| {
+    //             LIB.as_ref().and_then(|lib| unsafe {
+    //                 //Get func, print and discard error as we don't need it again
+    //                 lib.get(b"wooting_analog_read_full_buffer_device").map_err(|e| {
+    //                     println!("Could not find symbol 'wooting_analog_read_full_buffer_device', {}", e);
+    //                 }).ok()
+    //             })
+    //         });
+
+    //         match READ_FN.as_deref() {
+    //             Some(f) => f(code_buffer, analog_buffer, len, device_id),
+    //             _ => WootingAnalogResult::FunctionNotFound.into(),
+    //         }
+    //     }
+    //     DllLocation::Local => {
+    //         println!("went through self");
+
+    //         let codes = unsafe {
+    //             assert!(!code_buffer.is_null());
+
+    //             slice::from_raw_parts_mut(code_buffer, len as usize)
+    //         };
+
+    //         let analog = unsafe {
+    //             assert!(!analog_buffer.is_null());
+
+    //             slice::from_raw_parts_mut(analog_buffer, len as usize)
+    //         };
+
+    //         match ANALOG_SDK
+    //             .lock()
+    //             .unwrap()
+    //             .read_full_buffer(len as usize, device_id)
+    //             .0
+    //         {
+    //             Ok(analog_data) => {
+    //                 //Fill up given slices
+    //                 let mut count: usize = 0;
+    //                 for (code, val) in analog_data.iter() {
+    //                     if count >= codes.len() {
+    //                         break;
+    //                     }
+
+    //                     codes[count] = *code;
+    //                     analog[count] = *val;
+    //                     count += 1;
+    //                 }
+    //                 count as c_int
+    //             }
+    //             Err(e) => e as c_int,
+    //         }
+    //     }
+    // }
+
+    // if USE_SYS_DLL.load(Ordering::Relaxed) {
+    //     static READ_FN: LazyLock<Option<Symbol<extern "C" fn(
+    //         *mut c_ushort,
+    //         *mut c_float,
+    //         c_uint,
+    //         DeviceID
+    //     ) -> i32>>> = LazyLock::new(|| {
+    //         LIB.as_ref().and_then(|lib| unsafe {
+    //             //Get func, print and discard error as we don't need it again
+    //             lib.get(b"wooting_analog_read_full_buffer_device").map_err(|e| {
+    //                 println!("Could not find symbol 'wooting_analog_read_full_buffer_device', {}", e);
+    //             }).ok()
+    //         })
+    //     });
+
+    //     return match READ_FN.as_deref() {
+    //         Some(f) => f(code_buffer, analog_buffer, len, device_id),
+    //         _ => WootingAnalogResult::FunctionNotFound.into()
+    //     }
+    // }
+
+    // let codes = unsafe {
+    //     assert!(!code_buffer.is_null());
+
+    //     slice::from_raw_parts_mut(code_buffer, len as usize)
+    // };
+
+    // let analog = unsafe {
+    //     assert!(!analog_buffer.is_null());
+
+    //     slice::from_raw_parts_mut(analog_buffer, len as usize)
+    // };
+
+    // println!("went through self");
+
+    // match ANALOG_SDK
+    //     .lock()
+    //     .unwrap()
+    //     .read_full_buffer(len as usize, device_id)
+    //     .0
+    // {
+    //     Ok(analog_data) => {
+    //         //Fill up given slices
+    //         let mut count: usize = 0;
+    //         for (code, val) in analog_data.iter() {
+    //             if count >= codes.len() {
+    //                 break;
+    //             }
+
+    //             codes[count] = *code;
+    //             analog[count] = *val;
+    //             count += 1;
+    //         }
+    //         count as c_int
+    //     }
+    //     Err(e) => e as c_int,
+    // }
+
+    // type FnPtr = unsafe extern "C" fn(code_buffer: *mut c_ushort,
+    //     analog_buffer: *mut c_float,
+    //     len: c_uint,
+    //     device_id: DeviceID) -> c_int;
+
+    // if LIB.is_some() {
+    //     if "wooting_analog_read_full_buffer_device" != "wooting_analog_version" && wooting_analog_version() >= 0 && wooting_analog_version() != 0 {
+    //         println!("Cannot access Wooting Analog SDK function as this wrapper is for SDK major version {}, whereas the SDK has major version {}", 0, wooting_analog_version());
+    //         return WootingAnalogResult::IncompatibleVersion.into()
+    //     }
+
+    //         static FUNC: LazyLock<Option<libloading::Symbol<'static, FnPtr>>> = LazyLock::new(|| {
+    //             LIB.as_ref().and_then(|lib| unsafe {
+    //                 //Get func, print and discard error as we don't need it again
+    //                 lib.get(b"wooting_analog_read_full_buffer_device").map_err(|_e| {
+    //                     println!("Could not find symbol '{}', {}", stringify!($fn_names), _e);
+    //                 }).ok()
+    //             })
+    //         });
+
+    //     match FUNC.as_deref() {
+    //         Some(f) => unsafe { f(code_buffer,
+    //     analog_buffer,
+    //     len,
+    //     device_id) },
+    //         _ => WootingAnalogResult::FunctionNotFound.into()
+    //     }
+    // } else {
+    //     let codes = unsafe {
+    //         assert!(!code_buffer.is_null());
+
+    //         slice::from_raw_parts_mut(code_buffer, len as usize)
+    //     };
+
+    //     let analog = unsafe {
+    //         assert!(!analog_buffer.is_null());
+
+    //         slice::from_raw_parts_mut(analog_buffer, len as usize)
+    //     };
+
+    //     println!("went through self");
+
+    //     match ANALOG_SDK
+    //         .lock()
+    //         .unwrap()
+    //         .read_full_buffer(len as usize, device_id)
+    //         .0
+    //     {
+    //         Ok(analog_data) => {
+    //             //Fill up given slices
+    //             let mut count: usize = 0;
+    //             for (code, val) in analog_data.iter() {
+    //                 if count >= codes.len() {
+    //                     break;
+    //                 }
+
+    //                 codes[count] = *code;
+    //                 analog[count] = *val;
+    //                 count += 1;
+    //             }
+    //             count as c_int
+    //         }
+    //         Err(e) => e as c_int,
+    //     }
+    // }
 }

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,6 +1,6 @@
 use crate::{DeviceEventType, DeviceID, DeviceInfo_FFI, WootingAnalogResult};
 use libloading::Symbol;
-use std::os::raw::{c_float, c_int, c_uint, c_ushort};
+use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
@@ -97,6 +97,21 @@ fn load_symbol<T>(name: &str) -> Option<Symbol<'_, T>> {
 }
 
 macro_rules! delegate_sys {
+    ($($fn_name:ident($($args:ident: $fn_args:ty),*) -> *const c_char;)*) => {
+        $(
+            #[must_use]
+            pub(in crate::ffi) fn $fn_name($($args: $fn_args),*) -> *const c_char {
+                static FN: LazyLock<Option<Symbol<fn($($fn_args),*) -> *const c_char>>> =
+                    LazyLock::new(|| load_symbol(stringify!($fn_name)));
+
+                return match FN.as_deref() {
+                    Some(f) => f($($args),*),
+                    None => std::ptr::null(),
+                };
+            }
+        )*
+    };
+
     ($($fn_name:ident($($args:ident: $fn_args:ty),*) $(-> $fn_ret:ty)*;)*) => {
         $(
             #[must_use]
@@ -106,7 +121,7 @@ macro_rules! delegate_sys {
 
                 return match FN.as_deref() {
                     Some(f) => f($($args),*),
-                    _ => WootingAnalogResult::FunctionNotFound.into(),
+                    None => WootingAnalogResult::FunctionNotFound.into(),
                 };
             }
         )*
@@ -135,4 +150,8 @@ delegate_sys! {
         len: c_uint,
         device_id: DeviceID
     ) -> c_int;
+}
+
+delegate_sys! {
+    wooting_analog_version_semver() -> *const c_char;
 }

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,7 +1,7 @@
 use crate::{DeviceEventType, DeviceID, DeviceInfo_FFI, WootingAnalogResult};
 use libloading::Symbol;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 static SDK_VERSION: LazyLock<i32> = LazyLock::new(|| {
@@ -20,13 +20,25 @@ pub static USE_SYS_DLL: LazyLock<bool> = LazyLock::new(|| {
 });
 
 static LIB: LazyLock<Option<libloading::Library>> = LazyLock::new(|| {
-    #[cfg(target_arch = "x86")]
-    let name = "wooting_analog_sdk32";
+    let base_name = if cfg!(target_arch = "x86") {
+        "wooting_analog_sdk32"
+    } else {
+        "wooting_analog_sdk"
+    };
 
-    #[cfg(not(target_arch = "x86"))]
-    let name = "wooting_analog_sdk";
+    let filename = libloading::library_filename(base_name);
 
-    let lib_path = find_dll_in_path(name).map(|p| p.join(libloading::library_filename(name)))?;
+    let sdk_root = if cfg!(target_os = "windows") {
+        Path::new("C:/Program Files/wooting-analog-sdk/")
+    } else if cfg!(target_os = "macos") {
+        Path::new("/usr/local/lib/")
+    } else {
+        Path::new("/usr/lib/")
+    };
+
+    let lib_path = Some(sdk_root.join(&filename))
+        .filter(|p| p.exists())
+        .or_else(|| find_dll_in_path(filename.to_str()?))?;
 
     unsafe {
         //Attempt to load the library, if it fails print the error and discard the error
@@ -38,15 +50,28 @@ static LIB: LazyLock<Option<libloading::Library>> = LazyLock::new(|| {
     }
 });
 
-fn find_dll_in_path(name: &str) -> Option<PathBuf> {
-    if let Ok(path_var) = std::env::var("PATH") {
-        for dir in std::env::split_paths(&path_var) {
-            if dir.is_dir() && dir.to_str().is_some_and(|d| d == name) {
-                return Some(dir);
-            }
+fn find_dll_in_path(filename: &str) -> Option<PathBuf> {
+    let search_env_var = |key: &str| -> Option<PathBuf> {
+        let env_val = std::env::var_os(key)?;
+        std::env::split_paths(&env_val).find(|dir| dir.join(filename).is_file())
+    };
+
+    #[cfg(target_os = "linux")]
+    if let Some(path) = search_env_var("LD_LIBRARY_PATH") {
+        return Some(path);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(path) = search_env_var("DYLD_LIBRARY_PATH") {
+            return Some(path);
+        }
+        if let Some(path) = search_env_var("LD_LIBRARY_PATH") {
+            return Some(path);
         }
     }
-    None
+
+    search_env_var("PATH")
 }
 
 fn try_system_dll() -> Result<(), WootingAnalogResult> {

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,0 +1,113 @@
+use crate::{DeviceEventType, DeviceID, DeviceInfo_FFI, WootingAnalogResult};
+use libloading::Symbol;
+use std::os::raw::{c_float, c_int, c_uint, c_ushort};
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+static SDK_VERSION: LazyLock<i32> = LazyLock::new(|| {
+    env!("CARGO_PKG_VERSION")
+        .split('.')
+        .collect::<Vec<&str>>()
+        .first()
+        .and_then(|v| v.parse().ok())
+        .expect("crate must have correct package semver format")
+});
+
+pub static USE_SYS_DLL: LazyLock<bool> = LazyLock::new(|| {
+    try_system_dll()
+        .inspect_err(|e| eprintln!("failed to delagate to system dll: {e:?}"))
+        .is_ok()
+});
+
+static LIB: LazyLock<Option<libloading::Library>> = LazyLock::new(|| {
+    #[cfg(target_arch = "x86")]
+    let name = "wooting_analog_sdk32";
+
+    #[cfg(not(target_arch = "x86"))]
+    let name = "wooting_analog_sdk";
+
+    let lib_path = find_dll_in_path(name).map(|p| p.join(libloading::library_filename(name)))?;
+
+    unsafe {
+        //Attempt to load the library, if it fails print the error and discard the error
+        libloading::Library::new(&lib_path)
+            .inspect_err(|e| {
+                eprintln!("unable to load library: {:?}\nErr: {}", lib_path, e);
+            })
+            .ok()
+    }
+});
+
+fn find_dll_in_path(name: &str) -> Option<PathBuf> {
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            if dir.is_dir() && dir.to_str().is_some_and(|d| d == name) {
+                return Some(dir);
+            }
+        }
+    }
+    None
+}
+
+fn try_system_dll() -> Result<(), WootingAnalogResult> {
+    if LIB.is_none() {
+        return Err(WootingAnalogResult::DLLNotFound);
+    }
+
+    if wooting_analog_version() == *SDK_VERSION {
+        Ok(())
+    } else {
+        Err(WootingAnalogResult::IncompatibleVersion)
+    }
+}
+
+fn load_symbol<T>(name: &str) -> Option<Symbol<'_, T>> {
+    LIB.as_ref().and_then(|lib| unsafe {
+        lib.get::<T>(name.as_bytes())
+            .inspect_err(|e| {
+                eprintln!("failed to load symbol '{}': {}", name, e);
+            })
+            .ok()
+    })
+}
+
+macro_rules! delegate_sys {
+    ($($fn_name:ident($($args:ident: $fn_args:ty),*) $(-> $fn_ret:ty)*;)*) => {
+        $(
+            #[must_use]
+            pub(crate) fn $fn_name($($args: $fn_args),*) $(-> $fn_ret)? {
+                static FN: LazyLock<Option<Symbol<fn($($fn_args),*) $(-> $fn_ret)*>>> =
+                    LazyLock::new(|| load_symbol(stringify!($fn_name)));
+
+                return match FN.as_deref() {
+                    Some(f) => f($($args),*),
+                    _ => WootingAnalogResult::FunctionNotFound.into(),
+                };
+            }
+        )*
+    };
+}
+
+delegate_sys! {
+    wooting_analog_initialise() -> c_int;
+    wooting_analog_version() -> c_int;
+    wooting_analog_is_initialised() -> bool;
+    wooting_analog_uninitialise() -> WootingAnalogResult;
+    wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult;
+    wooting_analog_read_analog(code: c_ushort) -> c_float;
+    wooting_analog_read_analog_device(code: c_ushort, device_id: DeviceID) -> c_float;
+    wooting_analog_set_device_event_cb(
+        cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI)
+    ) -> WootingAnalogResult;
+    wooting_analog_clear_device_event_cb() -> WootingAnalogResult;
+    wooting_analog_get_connected_devices_info(
+        buffer: *mut *mut DeviceInfo_FFI,
+        len: c_uint
+    ) -> c_int;
+    wooting_analog_read_full_buffer_device(
+        code_buffer: *mut c_ushort,
+        analog_buffer: *mut c_float,
+        len: c_uint,
+        device_id: DeviceID
+    ) -> c_int;
+}

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -75,7 +75,7 @@ macro_rules! delegate_sys {
     ($($fn_name:ident($($args:ident: $fn_args:ty),*) $(-> $fn_ret:ty)*;)*) => {
         $(
             #[must_use]
-            pub(crate) fn $fn_name($($args: $fn_args),*) $(-> $fn_ret)? {
+            pub(in crate::ffi) fn $fn_name($($args: $fn_args),*) $(-> $fn_ret)? {
                 static FN: LazyLock<Option<Symbol<fn($($fn_args),*) $(-> $fn_ret)*>>> =
                     LazyLock::new(|| load_symbol(stringify!($fn_name)));
 

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -195,7 +195,7 @@ pub enum DeviceEventType {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone, Primitive, Error)]
+#[derive(Debug, PartialEq, Clone, Primitive, Error, Copy)]
 #[repr(C)]
 pub enum WootingAnalogResult {
     #[error("All OK")]


### PR DESCRIPTION
Fixes: K-1189, K-1188, K-1208

All commands to compile the SDK with their respective features and targets work as expected

```sh
# build system (debug)
cargo build --features ffi
```
- [x] Windows 
```sh
# build dist (debug,)
cargo rustc --features ffi,dist -- \
    -C link-arg=/OUT:target/debug/wooting_analog_sdk_dist.dll \
    -C link-arg=/IMPLIB:target/debug/wooting_analog_sdk_dist.lib
```
- [x] Linux
```sh
# build dist (debug)
cargo rustc --features ffi,dist -- \
    -C link-arg=-Wl,-soname,./target/debug/libwooting_analog_sdk_dist.so \
    -C link-arg=-Wl,-o,libwooting_analog_sdk_dist.so
```
- [x] MacOS
```sh
# build dist (debug)
cargo rustc --features ffi,dist -- \
    -C link-arg=-Wl,-install_name,libwooting_analog_sdk_dist.dylib \
    -C link-arg=-Wl,-o,libwooting_analog_sdk_dist.dylib
```
---
```sh
# aliases for the above commands
# available from workspace root
cargo dist-win
cargo dist-linux
cargo dist-mac

# building the system variant is as simple as:
cargo build --release --features ffi
```
