### PR TITLE
Fix panic in read_full_buffer with multiple devices

### DIFF
--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -409,9 +409,13 @@ impl AnalogSDK {
         let mut any_success = false;
         //Read from all and add up
         for p in self.plugins.iter_mut() {
-            let plugin_data = p
-                .read_full_buffer(max_length - analog_data.len(), device_id)
-                .into();
+            // Check if we've already collected enough data
+            if analog_data.len() >= max_length {
+                break;
+            }
+
+            let remaining = max_length.saturating_sub(analog_data.len());
+            let plugin_data = p.read_full_buffer(remaining, device_id).into();
             match plugin_data {
                 Ok(mut data) => {
                     for (hid_code, analog) in data.drain() {


### PR DESCRIPTION
## Summary

Fixes #43

When multiple devices are connected and the first device returns more results than `max_length`, the subtraction `max_length - analog_data.len()` in `read_full_buffer` would underflow (since `usize` is unsigned), causing a panic.

This fix:
- Adds an early check to break out of the loop if we've already collected `max_length` entries
- Uses `saturating_sub` to safely compute the remaining capacity, preventing any potential underflow

## Test plan

- [ ] Build passes with `cargo build --package wooting-analog-sdk`
- [ ] Existing tests continue to pass
- [ ] Manual testing with multiple analog devices where the first device returns more data than requested