### PR TITLE
Group advanced key context into their underlying bind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/WootingKb/wooting-analog-sdk"
 homepage = "https://github.com/WootingKb/wooting-analog-sdk"
 keywords = ["wooting", "keyboard", "analog", "sdk"]
 publish = false
-rust-version = "1.85.1"
+rust-version = "1.88.0"
 
 [workspace.dependencies]
 log = "0.4"

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -166,12 +166,10 @@ pub enum KeycodeType {
     VirtualKeyTranslate = 3,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(C)]
 pub enum KeyNamespace {
-    #[default]
     HidNormal = 1,
-    HidModifier = 2,
     HidFunction = 3,
     CustomFunction = 4,
     GamepadBinding = 5,
@@ -181,13 +179,13 @@ pub enum KeyNamespace {
 impl From<u8> for KeyNamespace {
     fn from(value: u8) -> Self {
         match value {
-            0 | 1 => KeyNamespace::HidNormal,
-            2 => KeyNamespace::HidModifier,
+            0 => KeyNamespace::HidNormal,
             3 => KeyNamespace::HidFunction,
             4 => KeyNamespace::CustomFunction,
             5 => KeyNamespace::GamepadBinding,
             6 => KeyNamespace::AKCBinding,
-            _ => KeyNamespace::default(),
+            // TODO: will apply error handling when reworking the Rust API
+            _ => unreachable!("missing or invalid key namespace: {value}"),
         }
     }
 }
@@ -210,8 +208,8 @@ impl From<u16> for AkcType {
             3 => AkcType::Toggle,
             4 => AkcType::RappySnappy,
             5 => AkcType::SOCD,
-            // TODO: can't have this
-            _ => AkcType::ModTap,
+            // TODO: will apply error handling when reworking the Rust API
+            _ => unreachable!("missing or invalid AKC type: {value}"),
         }
     }
 }

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -2,9 +2,9 @@
 pub mod ffi;
 pub mod keycode;
 mod plugin;
+pub mod sdk;
 #[cfg(feature = "virtual-input")]
 mod virtual_input;
-pub mod sdk;
 
 pub use crate::plugin::Plugin;
 use enum_primitive_derive::Primitive;
@@ -167,11 +167,67 @@ pub enum KeycodeType {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(C)]
+pub enum KeyNamespace {
+    #[default]
+    HidNormal = 1,
+    HidModifier = 2,
+    HidFunction = 3,
+    CustomFunction = 4,
+    GamepadBinding = 5,
+    AKCBinding = 6,
+}
+
+impl From<u8> for KeyNamespace {
+    fn from(value: u8) -> Self {
+        match value {
+            0 | 1 => KeyNamespace::HidNormal,
+            2 => KeyNamespace::HidModifier,
+            3 => KeyNamespace::HidFunction,
+            4 => KeyNamespace::CustomFunction,
+            5 => KeyNamespace::GamepadBinding,
+            6 => KeyNamespace::AKCBinding,
+            _ => KeyNamespace::default(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[repr(C)]
+pub enum AkcType {
+    DKS = 1,
+    ModTap = 2,
+    Toggle = 3,
+    RappySnappy = 4,
+    SOCD = 5,
+}
+
+impl From<u16> for AkcType {
+    fn from(value: u16) -> Self {
+        match value {
+            1 => AkcType::DKS,
+            2 => AkcType::ModTap,
+            3 => AkcType::Toggle,
+            4 => AkcType::RappySnappy,
+            5 => AkcType::SOCD,
+            // TODO: can't have this
+            _ => AkcType::ModTap,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct AkcContext {
+    akc_type: AkcType,
+    actuated: bool,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub enum KeyMetadata {
     #[default]
     None,
     Basic {
-        namespace: u8,
+        namespace: KeyNamespace,
     },
 }
 
@@ -190,6 +246,13 @@ impl KeyCode {
         self.metadata = meta;
         self
     }
+
+    pub fn is_advanced_key(&self) -> bool {
+        match self.metadata {
+            KeyMetadata::None => false,
+            KeyMetadata::Basic { namespace, .. } => namespace == KeyNamespace::AKCBinding,
+        }
+    }
 }
 
 impl std::hash::Hash for KeyCode {
@@ -206,7 +269,7 @@ impl PartialEq for KeyCode {
 
 impl PartialOrd for KeyCode {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.inner.cmp(&other.inner))
+        Some(self.cmp(other))
     }
 }
 
@@ -241,6 +304,7 @@ pub enum ValueMetadata {
     Basic {
         pos: Position,
         actuated: bool,
+        akc_ctx: Option<AkcContext>,
     },
 }
 
@@ -278,6 +342,24 @@ impl AnalogValue {
     pub fn with_metadata(mut self, meta: ValueMetadata) -> Self {
         self.metadata = meta;
         self
+    }
+
+    pub fn is_position_eq(&self, other: &Self) -> bool {
+        if let ValueMetadata::Basic { pos: a, .. } = self.metadata
+            && let ValueMetadata::Basic { pos: b, .. } = other.metadata
+        {
+            a == b
+        } else {
+            false
+        }
+    }
+
+    pub fn is_actuated(&self) -> bool {
+        if let ValueMetadata::Basic { actuated, .. } = self.metadata {
+            actuated
+        } else {
+            false
+        }
     }
 }
 

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -277,7 +277,7 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
             }
         }
 
-        let (mut entries, akc_entries): (HashMap<_, _>, HashMap<_, _>) = buffer
+        let (akc_entries, mut entries): (HashMap<_, _>, HashMap<_, _>) = buffer
             .chunks_exact(4)
             .take(max_length)
             .filter(|&b| b[1] != 0)
@@ -309,7 +309,7 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                     ),
                 )
             })
-            .partition(|(k, _v)| !k.is_advanced_key());
+            .partition(|(k, _v)| k.is_advanced_key());
 
         for (key, value) in entries.iter_mut() {
             if !key.is_advanced_key() {

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -6,6 +6,7 @@ use hidapi::{HidApi, HidDevice};
 use log::*;
 use log::{error, info};
 use std::borrow::Borrow;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::os::raw::{c_float, c_ushort};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -16,8 +17,8 @@ use std::{str, thread};
 #[cfg(feature = "virtual-input")]
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, KeyCode, KeyMetadata, Position,
-    SDKResult, ValueMetadata, WootingAnalogResult,
+    AkcContext, AkcType, AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, KeyCode,
+    KeyMetadata, KeyNamespace, Position, SDKResult, ValueMetadata, WootingAnalogResult,
 };
 
 #[cfg(target_os = "macos")]
@@ -220,7 +221,9 @@ impl DeviceImplementation for WootingNewFirmware {
 }
 
 #[derive(Debug, Clone)]
-struct WootingAnalogProtocolV2;
+struct WootingAnalogProtocolV2 {
+    drop_idx_scratchpad: RefCell<Vec<usize>>,
+}
 
 impl DeviceImplementation for WootingAnalogProtocolV2 {
     fn device_hardware_id(&self) -> DeviceHardwareID {
@@ -273,41 +276,73 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                 return Err(WootingAnalogResult::DeviceDisconnected).into();
             }
         }
-        Ok(Some(
-            buffer
-                .chunks_exact(4)
-                .take(max_length)
-                .filter(|&b| b[3] != 0)
-                .map(|b| {
-                    let matrix_pos = b[0];
-                    let key = b[1];
-                    let packed = b[2];
-                    let value = b[3];
 
-                    let row = (matrix_pos >> 5) & 0x07;
-                    let col = matrix_pos & 0x1F;
-                    let actuated = (packed & 0x01) != 0;
-                    let _reserved = packed >> 1;
-                    let key_namespace = (packed >> 2) & 0x0F;
-                    let value_part = (packed >> 6) & 0x03;
+        let (mut entries, akc_entries): (HashMap<_, _>, HashMap<_, _>) = buffer
+            .chunks_exact(4)
+            .take(max_length)
+            .filter(|&b| b[1] != 0)
+            .map(|b| {
+                let matrix_pos = b[0];
+                let key = b[1];
+                let packed = b[2];
+                let value = b[3];
 
-                    let value = (u16::from(value) << 2) | u16::from(value_part);
+                let row = (matrix_pos >> 5) & 0x07;
+                let col = matrix_pos & 0x1F;
+                let actuated = (packed & 0x01) != 0;
+                let _reserved = packed >> 1;
+                let key_namespace = (packed >> 2) & 0x0F;
+                let value_part = (packed >> 6) & 0x03;
 
-                    (
-                        KeyCode::from(key).with_metadata(KeyMetadata::Basic {
-                            namespace: key_namespace,
-                        }),
-                        AnalogValue::from(self.analog_value_to_float(value)).with_metadata(
-                            ValueMetadata::Basic {
-                                pos: Position::new(col, row),
-                                actuated,
-                            },
-                        ),
-                    )
-                })
-                .collect(),
-        ))
-        .into()
+                let value = (u16::from(value) << 2) | u16::from(value_part);
+
+                (
+                    KeyCode::from(key).with_metadata(KeyMetadata::Basic {
+                        namespace: KeyNamespace::from(key_namespace),
+                    }),
+                    AnalogValue::from(self.analog_value_to_float(value)).with_metadata(
+                        ValueMetadata::Basic {
+                            pos: Position::new(col, row),
+                            actuated,
+                            akc_ctx: None,
+                        },
+                    ),
+                )
+            })
+            .partition(|(k, _v)| !k.is_advanced_key());
+
+        for (key, value) in entries.iter_mut() {
+            if !key.is_advanced_key() {
+                let akc_entry = akc_entries
+                    .iter()
+                    .enumerate()
+                    .find(|(_idx, (k, v))| k.is_advanced_key() && v.is_position_eq(value));
+
+                if let Some((idx, (k, v))) = akc_entry {
+                    let ctx = AkcContext {
+                        akc_type: AkcType::from(k.inner),
+                        actuated: v.is_actuated(),
+                    };
+                    if let ValueMetadata::Basic { akc_ctx, .. } = &mut value.metadata {
+                        *akc_ctx = Some(ctx);
+                        self.drop_idx_scratchpad.borrow_mut().push(idx);
+                    }
+                }
+            }
+        }
+
+        for (k, v) in akc_entries
+            .into_iter()
+            .enumerate()
+            .filter(|(idx, _)| !self.drop_idx_scratchpad.borrow().contains(idx))
+            .map(|(_idx, (k, v))| (k, v))
+        {
+            entries.insert(k, v);
+        }
+
+        self.drop_idx_scratchpad.borrow_mut().clear();
+
+        Ok(Some(entries)).into()
     }
 
     fn analog_value_to_float(&self, value: u16) -> f32 {
@@ -557,7 +592,9 @@ impl WootingPlugin {
             Box::new(WootingOne),
             Box::new(WootingTwo),
             Box::new(WootingNewFirmware),
-            Box::new(WootingAnalogProtocolV2),
+            Box::new(WootingAnalogProtocolV2 {
+                drop_idx_scratchpad: RefCell::new(Vec::new()),
+            }),
         ];
         let mut hid = match HidApi::new_without_enumerate() {
             Ok(mut api) => {


### PR DESCRIPTION
Will introduce better error handling once the whole Rust API gets refactored, for now we panic when we see an AKC type or key namespace that we don't recognize. 