### PR TITLE
Expose additional protocol context for keys over FFI

### DIFF
--- a/includes/wooting-analog-sdk.h
+++ b/includes/wooting-analog-sdk.h
@@ -31,9 +31,15 @@ typedef enum WootingAnalogResult {
   WootingAnalogResult_IncompatibleVersion = -1991,
   /// Indicates that the Analog SDK could not be found on the system
   WootingAnalogResult_DLLNotFound = -1990,
-  /// Device does not have the required analog protocol
-  WootingAnalogResult_IncompatibleAnalogProtocol = -1989,
 } WootingAnalogResult;
+
+typedef enum WootingAnalog_KeyNamespace {
+  WootingAnalog_KeyNamespace_HidNormal = 1,
+  WootingAnalog_KeyNamespace_HidFunction = 3,
+  WootingAnalog_KeyNamespace_CustomFunction = 4,
+  WootingAnalog_KeyNamespace_GamepadBinding = 5,
+  WootingAnalog_KeyNamespace_AdvancedKey = 6,
+} WootingAnalog_KeyNamespace;
 
 typedef enum WootingAnalog_DeviceEventType {
   /// Device has been connected
@@ -62,10 +68,38 @@ typedef enum WootingAnalog_DeviceType {
   WootingAnalog_DeviceType_Other = 3,
 } WootingAnalog_DeviceType;
 
-typedef struct WootingAnalog_Position {
+enum WootingAnalog_KeyMetadata_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  WootingAnalog_KeyMetadata_None,
+  WootingAnalog_KeyMetadata_Basic,
+};
+#ifndef __cplusplus
+typedef uint8_t WootingAnalog_KeyMetadata_Tag;
+#endif // __cplusplus
+
+typedef struct WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body {
+  enum WootingAnalog_KeyNamespace namespace_;
+} WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body;
+
+typedef struct WootingAnalog_KeyMetadata {
+  WootingAnalog_KeyMetadata_Tag tag;
+  union {
+    WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body basic;
+  };
+} WootingAnalog_KeyMetadata;
+
+typedef struct WootingAnalog_KeyCode {
+  uint16_t inner;
+  struct WootingAnalog_KeyMetadata metadata;
+} WootingAnalog_KeyCode;
+
+typedef struct WootingAnalog_KeyPosition {
   uint8_t x;
   uint8_t y;
-} WootingAnalog_Position;
+} WootingAnalog_KeyPosition;
 
 enum WootingAnalog_KeySource_Tag
 #ifdef __cplusplus
@@ -73,6 +107,7 @@ enum WootingAnalog_KeySource_Tag
 #endif // __cplusplus
  {
   WootingAnalog_KeySource_Raw,
+  WootingAnalog_KeySource_Code,
   WootingAnalog_KeySource_Position,
 };
 #ifndef __cplusplus
@@ -86,7 +121,10 @@ typedef struct WootingAnalog_KeySource {
       uint16_t raw;
     };
     struct {
-      struct WootingAnalog_Position position;
+      struct WootingAnalog_KeyCode code;
+    };
+    struct {
+      struct WootingAnalog_KeyPosition position;
     };
   };
 } WootingAnalog_KeySource;
@@ -104,7 +142,7 @@ typedef uint8_t WootingAnalog_ValueMetadata_Tag;
 #endif // __cplusplus
 
 typedef struct WootingAnalog_ValueMetadata_WootingAnalog_Basic_Body {
-  struct WootingAnalog_Position pos;
+  struct WootingAnalog_KeyPosition pos;
   bool actuated;
 } WootingAnalog_ValueMetadata_WootingAnalog_Basic_Body;
 
@@ -140,34 +178,6 @@ typedef struct WootingAnalog_DeviceInfo_FFI {
   /// Hardware type of the Device see `DeviceType` enum
   WootingAnalog_DeviceType device_type;
 } WootingAnalog_DeviceInfo_FFI;
-
-enum WootingAnalog_KeyMetadata_Tag
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
-  WootingAnalog_KeyMetadata_None,
-  WootingAnalog_KeyMetadata_Basic,
-};
-#ifndef __cplusplus
-typedef uint8_t WootingAnalog_KeyMetadata_Tag;
-#endif // __cplusplus
-
-typedef struct WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body {
-  uint8_t namespace_;
-} WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body;
-
-typedef struct WootingAnalog_KeyMetadata {
-  WootingAnalog_KeyMetadata_Tag tag;
-  union {
-    WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body basic;
-  };
-} WootingAnalog_KeyMetadata;
-
-typedef struct WootingAnalog_KeyCode {
-  uint16_t inner;
-  struct WootingAnalog_KeyMetadata metadata;
-} WootingAnalog_KeyCode;
 
 #ifdef __cplusplus
 extern "C" {
@@ -254,6 +264,10 @@ enum WootingAnalogResult wooting_analog_read_analog_with_ctx(const struct Wootin
 float wooting_analog_read_analog_device(unsigned short code,
                                         WootingAnalog_DeviceID device_id);
 
+enum WootingAnalogResult wooting_analog_read_analog_device_with_ctx(const struct WootingAnalog_KeySource *key_source,
+                                                                    struct WootingAnalog_AnalogValue *value,
+                                                                    WootingAnalog_DeviceID device_id);
+
 /// Set the callback which is called when there is a DeviceEvent. Currently these events can either be Disconnected or Connected(Currently not properly implemented).
 /// The callback gets given the type of event `DeviceEventType` and a pointer to the DeviceInfo struct that the event applies to
 ///
@@ -332,7 +346,7 @@ int wooting_analog_read_full_buffer_device(unsigned short *code_buffer,
                                            unsigned int len,
                                            WootingAnalog_DeviceID device_id);
 
-int wooting_analog_read_full_buffer_with_ctx_device(struct WootingAnalog_KeyCode *code_buffer,
+int wooting_analog_read_full_buffer_device_with_ctx(struct WootingAnalog_KeyCode *code_buffer,
                                                     struct WootingAnalog_AnalogValue *analog_buffer,
                                                     unsigned int len,
                                                     WootingAnalog_DeviceID device_id);

--- a/includes/wooting-analog-sdk.h
+++ b/includes/wooting-analog-sdk.h
@@ -71,66 +71,12 @@ typedef enum WootingAnalog_DeviceType {
   WootingAnalog_DeviceType_Other = 3,
 } WootingAnalog_DeviceType;
 
-enum WootingAnalog_KeyMetadata_Tag
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
-  WootingAnalog_KeyMetadata_None,
-  WootingAnalog_KeyMetadata_Basic,
-};
-#ifndef __cplusplus
-typedef uint8_t WootingAnalog_KeyMetadata_Tag;
-#endif // __cplusplus
-
-typedef struct WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body {
-  enum WootingAnalog_KeyNamespace namespace_;
-} WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body;
-
-typedef struct WootingAnalog_KeyMetadata {
-  WootingAnalog_KeyMetadata_Tag tag;
-  union {
-    WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body basic;
-  };
-} WootingAnalog_KeyMetadata;
-
-typedef struct WootingAnalog_KeyCode {
-  uint16_t inner;
-  struct WootingAnalog_KeyMetadata metadata;
-} WootingAnalog_KeyCode;
+typedef uint64_t WootingAnalog_DeviceID;
 
 typedef struct WootingAnalog_KeyPosition {
   uint8_t x;
   uint8_t y;
 } WootingAnalog_KeyPosition;
-
-enum WootingAnalog_KeySource_Tag
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
-  WootingAnalog_KeySource_Raw,
-  WootingAnalog_KeySource_Code,
-  WootingAnalog_KeySource_Position,
-};
-#ifndef __cplusplus
-typedef uint8_t WootingAnalog_KeySource_Tag;
-#endif // __cplusplus
-
-typedef struct WootingAnalog_KeySource {
-  WootingAnalog_KeySource_Tag tag;
-  union {
-    struct {
-      uint16_t raw;
-    };
-    struct {
-      struct WootingAnalog_KeyCode code;
-    };
-    struct {
-      struct WootingAnalog_KeyPosition position;
-    };
-  };
-} WootingAnalog_KeySource;
 
 enum WootingAnalog_ValueMetadata_Tag
 #ifdef __cplusplus
@@ -161,7 +107,45 @@ typedef struct WootingAnalog_AnalogValue {
   struct WootingAnalog_ValueMetadata metadata;
 } WootingAnalog_AnalogValue;
 
-typedef uint64_t WootingAnalog_DeviceID;
+enum WootingAnalog_KeyMetadata_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  WootingAnalog_KeyMetadata_None,
+  WootingAnalog_KeyMetadata_Basic,
+};
+#ifndef __cplusplus
+typedef uint8_t WootingAnalog_KeyMetadata_Tag;
+#endif // __cplusplus
+
+typedef struct WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body {
+  enum WootingAnalog_KeyNamespace namespace_;
+} WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body;
+
+typedef struct WootingAnalog_KeyMetadata {
+  WootingAnalog_KeyMetadata_Tag tag;
+  union {
+    WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body basic;
+  };
+} WootingAnalog_KeyMetadata;
+
+typedef struct WootingAnalog_KeyCode {
+  uint16_t inner;
+  struct WootingAnalog_KeyMetadata metadata;
+} WootingAnalog_KeyCode;
+
+typedef struct WootingAnalog_KeyState {
+  float value;
+  struct WootingAnalog_KeyCode keycode;
+  bool actuated;
+} WootingAnalog_KeyState;
+
+typedef struct WootingAnalog_PhysicalKey {
+  struct WootingAnalog_KeyPosition pos;
+  uint8_t state_count;
+  struct WootingAnalog_KeyState states[WootingAnalog_MAX_KEY_STATES];
+} WootingAnalog_PhysicalKey;
 
 /// The core `DeviceInfo` struct which contains all the interesting information
 /// for a particular device. This is the version which the consumer of the SDK will receive
@@ -181,45 +165,6 @@ typedef struct WootingAnalog_DeviceInfo_FFI {
   /// Hardware type of the Device see `DeviceType` enum
   WootingAnalog_DeviceType device_type;
 } WootingAnalog_DeviceInfo_FFI;
-
-typedef struct WootingAnalog_KeyState {
-  float value;
-  struct WootingAnalog_KeyCode keycode;
-  bool actuated;
-} WootingAnalog_KeyState;
-
-typedef struct WootingAnalog_PhysicalKey {
-  struct WootingAnalog_KeyPosition pos;
-  uint8_t state_count;
-  struct WootingAnalog_KeyState states[WootingAnalog_MAX_KEY_STATES];
-} WootingAnalog_PhysicalKey;
-
-enum WootingAnalog_V2Data_Tag
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
-  WootingAnalog_V2Data_V1,
-  WootingAnalog_V2Data_V2,
-};
-#ifndef __cplusplus
-typedef uint8_t WootingAnalog_V2Data_Tag;
-#endif // __cplusplus
-
-typedef struct WootingAnalog_V2Data_WootingAnalog_V1_Body {
-  uint16_t keycode;
-  float value;
-} WootingAnalog_V2Data_WootingAnalog_V1_Body;
-
-typedef struct WootingAnalog_V2Data {
-  WootingAnalog_V2Data_Tag tag;
-  union {
-    WootingAnalog_V2Data_WootingAnalog_V1_Body v1;
-    struct {
-      struct WootingAnalog_PhysicalKey v2;
-    };
-  };
-} WootingAnalog_V2Data;
 
 #ifdef __cplusplus
 extern "C" {
@@ -288,9 +233,6 @@ enum WootingAnalogResult wooting_analog_set_keycode_mode(unsigned int mode);
 /// * `WootingAnalogResult::NoDevices`: There are no connected devices
 float wooting_analog_read_analog(unsigned short code);
 
-enum WootingAnalogResult wooting_analog_read_analog_with_ctx(const struct WootingAnalog_KeySource *key_source,
-                                                             struct WootingAnalog_AnalogValue *value);
-
 /// Reads the Analog value of the key with identifier `code` from the device with id `device_id`. The set of key identifiers that is used
 /// depends on the Keycode mode set using `wooting_analog_set_mode`.
 ///
@@ -306,9 +248,13 @@ enum WootingAnalogResult wooting_analog_read_analog_with_ctx(const struct Wootin
 float wooting_analog_read_analog_device(unsigned short code,
                                         WootingAnalog_DeviceID device_id);
 
-enum WootingAnalogResult wooting_analog_read_analog_device_with_ctx(const struct WootingAnalog_KeySource *key_source,
-                                                                    struct WootingAnalog_AnalogValue *value,
-                                                                    WootingAnalog_DeviceID device_id);
+enum WootingAnalogResult wooting_analog_read_keycode_device(unsigned short keycode,
+                                                            struct WootingAnalog_AnalogValue *value,
+                                                            WootingAnalog_DeviceID device_id);
+
+enum WootingAnalogResult wooting_analog_read_position_device(struct WootingAnalog_KeyPosition *position,
+                                                             struct WootingAnalog_PhysicalKey *physical_key,
+                                                             WootingAnalog_DeviceID device_id);
 
 /// Set the callback which is called when there is a DeviceEvent. Currently these events can either be Disconnected or Connected(Currently not properly implemented).
 /// The callback gets given the type of event `DeviceEventType` and a pointer to the DeviceInfo struct that the event applies to
@@ -363,9 +309,6 @@ int wooting_analog_read_full_buffer(unsigned short *code_buffer,
                                     float *analog_buffer,
                                     unsigned int len);
 
-int wooting_analog_read_full_buffer_with_ctx(struct WootingAnalog_V2Data *data_buffer,
-                                             unsigned int len);
-
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
 /// keycode identifying the pressed key and fills up `analog_buffer` with the corresponding float analog values. i.e. The analog
 /// value for they key at index 0 of code_buffer, is at index 0 of analog_buffer.
@@ -387,9 +330,14 @@ int wooting_analog_read_full_buffer_device(unsigned short *code_buffer,
                                            unsigned int len,
                                            WootingAnalog_DeviceID device_id);
 
-int wooting_analog_read_full_buffer_device_with_ctx(struct WootingAnalog_V2Data *data_buffer,
-                                                    unsigned int len,
-                                                    WootingAnalog_DeviceID device_id);
+int wooting_analog_read_keycodes_device(struct WootingAnalog_KeyCode *code_buffer,
+                                        struct WootingAnalog_AnalogValue *analog_buffer,
+                                        unsigned int len,
+                                        WootingAnalog_DeviceID device_id);
+
+int wooting_analog_read_positions_device(struct WootingAnalog_PhysicalKey *physical_keys,
+                                         unsigned int len,
+                                         WootingAnalog_DeviceID device_id);
 
 bool wooting_analog_using_sys(void);
 

--- a/includes/wooting-analog-sdk.h
+++ b/includes/wooting-analog-sdk.h
@@ -31,6 +31,8 @@ typedef enum WootingAnalogResult {
   WootingAnalogResult_IncompatibleVersion = -1991,
   /// Indicates that the Analog SDK could not be found on the system
   WootingAnalogResult_DLLNotFound = -1990,
+  /// Device does not have the required analog protocol
+  WootingAnalogResult_IncompatibleAnalogProtocol = -1989,
 } WootingAnalogResult;
 
 typedef enum WootingAnalog_DeviceEventType {
@@ -59,6 +61,64 @@ typedef enum WootingAnalog_DeviceType {
   /// Device
   WootingAnalog_DeviceType_Other = 3,
 } WootingAnalog_DeviceType;
+
+typedef struct WootingAnalog_Position {
+  uint8_t x;
+  uint8_t y;
+} WootingAnalog_Position;
+
+enum WootingAnalog_KeySource_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  WootingAnalog_KeySource_Code,
+  WootingAnalog_KeySource_Position,
+};
+#ifndef __cplusplus
+typedef uint8_t WootingAnalog_KeySource_Tag;
+#endif // __cplusplus
+
+typedef struct WootingAnalog_KeySource {
+  WootingAnalog_KeySource_Tag tag;
+  union {
+    struct {
+      uint16_t code;
+    };
+    struct {
+      struct WootingAnalog_Position position;
+    };
+  };
+} WootingAnalog_KeySource;
+
+enum WootingAnalog_ValueMetadata_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  WootingAnalog_ValueMetadata_None,
+  WootingAnalog_ValueMetadata_Basic,
+};
+#ifndef __cplusplus
+typedef uint8_t WootingAnalog_ValueMetadata_Tag;
+#endif // __cplusplus
+
+typedef struct WootingAnalog_ValueMetadata_WootingAnalog_Basic_Body {
+  struct WootingAnalog_Position pos;
+  bool actuated;
+} WootingAnalog_ValueMetadata_WootingAnalog_Basic_Body;
+
+typedef struct WootingAnalog_ValueMetadata {
+  WootingAnalog_ValueMetadata_Tag tag;
+  union {
+    WootingAnalog_ValueMetadata_WootingAnalog_Basic_Body basic;
+  };
+} WootingAnalog_ValueMetadata;
+
+typedef struct WootingAnalog_AnalogValue {
+  float inner;
+  struct WootingAnalog_ValueMetadata metadata;
+} WootingAnalog_AnalogValue;
 
 typedef uint64_t WootingAnalog_DeviceID;
 
@@ -147,6 +207,9 @@ enum WootingAnalogResult wooting_analog_set_keycode_mode(unsigned int mode);
 /// * `WootingAnalogResult::UnInitialized`: The SDK is not initialised
 /// * `WootingAnalogResult::NoDevices`: There are no connected devices
 float wooting_analog_read_analog(unsigned short code);
+
+enum WootingAnalogResult wooting_analog_read_analog_with_ctx(const struct WootingAnalog_KeySource *key_source,
+                                                             struct WootingAnalog_AnalogValue *value);
 
 /// Reads the Analog value of the key with identifier `code` from the device with id `device_id`. The set of key identifiers that is used
 /// depends on the Keycode mode set using `wooting_analog_set_mode`.

--- a/includes/wooting-analog-sdk.h
+++ b/includes/wooting-analog-sdk.h
@@ -7,6 +7,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/// Maximum number of active binds per physical key (DKS has 4 underlying binds + advanced key entry)
+#define WootingAnalog_MAX_KEY_STATES 5
+
 typedef enum WootingAnalogResult {
   WootingAnalogResult_Ok = 1,
   /// Item hasn't been initialized
@@ -179,6 +182,18 @@ typedef struct WootingAnalog_DeviceInfo_FFI {
   WootingAnalog_DeviceType device_type;
 } WootingAnalog_DeviceInfo_FFI;
 
+typedef struct WootingAnalog_KeyState {
+  float value;
+  struct WootingAnalog_KeyCode keycode;
+  bool actuated;
+} WootingAnalog_KeyState;
+
+typedef struct WootingAnalog_PhysicalKey {
+  struct WootingAnalog_KeyPosition pos;
+  uint8_t state_count;
+  struct WootingAnalog_KeyState states[WootingAnalog_MAX_KEY_STATES];
+} WootingAnalog_PhysicalKey;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -321,8 +336,7 @@ int wooting_analog_read_full_buffer(unsigned short *code_buffer,
                                     float *analog_buffer,
                                     unsigned int len);
 
-int wooting_analog_read_full_buffer_with_ctx(struct WootingAnalog_KeyCode *code_buffer,
-                                             struct WootingAnalog_AnalogValue *analog_buffer,
+int wooting_analog_read_full_buffer_with_ctx(struct WootingAnalog_PhysicalKey *physical_keys,
                                              unsigned int len);
 
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
@@ -346,8 +360,7 @@ int wooting_analog_read_full_buffer_device(unsigned short *code_buffer,
                                            unsigned int len,
                                            WootingAnalog_DeviceID device_id);
 
-int wooting_analog_read_full_buffer_device_with_ctx(struct WootingAnalog_KeyCode *code_buffer,
-                                                    struct WootingAnalog_AnalogValue *analog_buffer,
+int wooting_analog_read_full_buffer_device_with_ctx(struct WootingAnalog_PhysicalKey *physical_keys,
                                                     unsigned int len,
                                                     WootingAnalog_DeviceID device_id);
 

--- a/includes/wooting-analog-sdk.h
+++ b/includes/wooting-analog-sdk.h
@@ -72,7 +72,7 @@ enum WootingAnalog_KeySource_Tag
   : uint8_t
 #endif // __cplusplus
  {
-  WootingAnalog_KeySource_Code,
+  WootingAnalog_KeySource_Raw,
   WootingAnalog_KeySource_Position,
 };
 #ifndef __cplusplus
@@ -83,7 +83,7 @@ typedef struct WootingAnalog_KeySource {
   WootingAnalog_KeySource_Tag tag;
   union {
     struct {
-      uint16_t code;
+      uint16_t raw;
     };
     struct {
       struct WootingAnalog_Position position;
@@ -140,6 +140,34 @@ typedef struct WootingAnalog_DeviceInfo_FFI {
   /// Hardware type of the Device see `DeviceType` enum
   WootingAnalog_DeviceType device_type;
 } WootingAnalog_DeviceInfo_FFI;
+
+enum WootingAnalog_KeyMetadata_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  WootingAnalog_KeyMetadata_None,
+  WootingAnalog_KeyMetadata_Basic,
+};
+#ifndef __cplusplus
+typedef uint8_t WootingAnalog_KeyMetadata_Tag;
+#endif // __cplusplus
+
+typedef struct WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body {
+  uint8_t namespace_;
+} WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body;
+
+typedef struct WootingAnalog_KeyMetadata {
+  WootingAnalog_KeyMetadata_Tag tag;
+  union {
+    WootingAnalog_KeyMetadata_WootingAnalog_Basic_Body basic;
+  };
+} WootingAnalog_KeyMetadata;
+
+typedef struct WootingAnalog_KeyCode {
+  uint16_t inner;
+  struct WootingAnalog_KeyMetadata metadata;
+} WootingAnalog_KeyCode;
 
 #ifdef __cplusplus
 extern "C" {
@@ -279,6 +307,10 @@ int wooting_analog_read_full_buffer(unsigned short *code_buffer,
                                     float *analog_buffer,
                                     unsigned int len);
 
+int wooting_analog_read_full_buffer_with_ctx(struct WootingAnalog_KeyCode *code_buffer,
+                                             struct WootingAnalog_AnalogValue *analog_buffer,
+                                             unsigned int len);
+
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
 /// keycode identifying the pressed key and fills up `analog_buffer` with the corresponding float analog values. i.e. The analog
 /// value for they key at index 0 of code_buffer, is at index 0 of analog_buffer.
@@ -299,6 +331,11 @@ int wooting_analog_read_full_buffer_device(unsigned short *code_buffer,
                                            float *analog_buffer,
                                            unsigned int len,
                                            WootingAnalog_DeviceID device_id);
+
+int wooting_analog_read_full_buffer_with_ctx_device(struct WootingAnalog_KeyCode *code_buffer,
+                                                    struct WootingAnalog_AnalogValue *analog_buffer,
+                                                    unsigned int len,
+                                                    WootingAnalog_DeviceID device_id);
 
 bool wooting_analog_using_sys(void);
 

--- a/includes/wooting-analog-sdk.h
+++ b/includes/wooting-analog-sdk.h
@@ -194,6 +194,33 @@ typedef struct WootingAnalog_PhysicalKey {
   struct WootingAnalog_KeyState states[WootingAnalog_MAX_KEY_STATES];
 } WootingAnalog_PhysicalKey;
 
+enum WootingAnalog_V2Data_Tag
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
+  WootingAnalog_V2Data_V1,
+  WootingAnalog_V2Data_V2,
+};
+#ifndef __cplusplus
+typedef uint8_t WootingAnalog_V2Data_Tag;
+#endif // __cplusplus
+
+typedef struct WootingAnalog_V2Data_WootingAnalog_V1_Body {
+  uint16_t keycode;
+  float value;
+} WootingAnalog_V2Data_WootingAnalog_V1_Body;
+
+typedef struct WootingAnalog_V2Data {
+  WootingAnalog_V2Data_Tag tag;
+  union {
+    WootingAnalog_V2Data_WootingAnalog_V1_Body v1;
+    struct {
+      struct WootingAnalog_PhysicalKey v2;
+    };
+  };
+} WootingAnalog_V2Data;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -336,7 +363,7 @@ int wooting_analog_read_full_buffer(unsigned short *code_buffer,
                                     float *analog_buffer,
                                     unsigned int len);
 
-int wooting_analog_read_full_buffer_with_ctx(struct WootingAnalog_PhysicalKey *physical_keys,
+int wooting_analog_read_full_buffer_with_ctx(struct WootingAnalog_V2Data *data_buffer,
                                              unsigned int len);
 
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
@@ -360,7 +387,7 @@ int wooting_analog_read_full_buffer_device(unsigned short *code_buffer,
                                            unsigned int len,
                                            WootingAnalog_DeviceID device_id);
 
-int wooting_analog_read_full_buffer_device_with_ctx(struct WootingAnalog_PhysicalKey *physical_keys,
+int wooting_analog_read_full_buffer_device_with_ctx(struct WootingAnalog_V2Data *data_buffer,
                                                     unsigned int len,
                                                     WootingAnalog_DeviceID device_id);
 

--- a/wooting-analog-sdk/cbindgen.toml
+++ b/wooting-analog-sdk/cbindgen.toml
@@ -14,6 +14,7 @@ include = [
     "WootingAnalogResult",
     "KeycodeType",
     "DeviceType",
+    "MAX_KEY_STATES",
 ]
 exclude = [
     "_plugin_create",
@@ -21,7 +22,7 @@ exclude = [
 ]
 prefix = "WootingAnalog_"
 renaming_overrides_prefixing = true
-item_types = ["enums", "structs", "typedefs", "functions", "opaque"]
+item_types = ["enums", "structs", "typedefs", "functions", "opaque", "constants"]
 
 [export.rename]
 "FfiStr" = "const char*"

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -504,9 +504,6 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 pub unsafe extern "C" fn wooting_analog_read_keycodes_device(
     code_buffer: *mut KeyCode,
     analog_buffer: *mut AnalogValue,
-    // physical_keys: *mut PhysicalKey,
-    // key_buffer: *mut V2DataKey,
-    // data_buffer: *mut V2Data,
     len: c_uint,
     device_id: DeviceID,
 ) -> c_int {

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -2,7 +2,9 @@
 mod delegate_sys;
 
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition, KeySource, KeycodeType, PhysicalKey, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
+    KeySource, KeycodeType, PhysicalKey, SDKResult, V2Data, ValueMetadata, WootingAnalogResult,
+    sdk::*,
 };
 #[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
@@ -421,7 +423,9 @@ pub extern "C" fn wooting_analog_read_full_buffer(
 pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx(
     // code_buffer: *mut KeyCode,
     // analog_buffer: *mut AnalogValue,
-    physical_keys: *mut PhysicalKey,
+    // physical_keys: *mut PhysicalKey,
+    // key_buffer: *mut V2DataKey,
+    data_buffer: *mut V2Data,
     len: c_uint,
 ) -> c_int {
     #[cfg(feature = "dist")]
@@ -429,13 +433,15 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx(
         return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
             // code_buffer,
             // analog_buffer,
-            physical_keys,
+            // physical_keys,
+            // key_buffer,
+            data_buffer,
             len,
             0,
         );
     }
 
-    unsafe { wooting_analog_read_full_buffer_device_with_ctx(physical_keys, len, 0) }
+    unsafe { wooting_analog_read_full_buffer_device_with_ctx(data_buffer, len, 0) }
 }
 
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
@@ -511,7 +517,9 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
     // code_buffer: *mut KeyCode,
     // analog_buffer: *mut AnalogValue,
-    physical_keys: *mut PhysicalKey,
+    // physical_keys: *mut PhysicalKey,
+    // key_buffer: *mut V2DataKey,
+    data_buffer: *mut V2Data,
     len: c_uint,
     device_id: DeviceID,
 ) -> c_int {
@@ -520,7 +528,9 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
         return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
             // code_buffer,
             // analog_buffer,
-            physical_keys,
+            // physical_keys,
+            // key_buffer,
+            data_buffer,
             len,
             device_id,
         );
@@ -538,10 +548,22 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
     //     slice::from_raw_parts_mut(analog_buffer, len as usize)
     // };
 
-    let keys = unsafe {
-        assert!(!physical_keys.is_null());
+    // let keys = unsafe {
+    //     assert!(!physical_keys.is_null());
 
-        slice::from_raw_parts_mut(physical_keys, len as usize)
+    //     slice::from_raw_parts_mut(physical_keys, len as usize)
+    // };
+
+    // let keys = unsafe {
+    //     assert!(!key_buffer.is_null());
+
+    //     slice::from_raw_parts_mut(key_buffer, len as usize)
+    // };
+
+    let values = unsafe {
+        assert!(!data_buffer.is_null());
+
+        slice::from_raw_parts_mut(data_buffer, len as usize)
     };
 
     match ANALOG_SDK
@@ -551,14 +573,14 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
         .0
     {
         Ok(analog_data) => {
-            //Fill up given slices
             let mut count: usize = 0;
-            for key in analog_data.iter() {
-                if count >= keys.len() {
+            for data in analog_data.into_vec() {
+                if count >= values.len() {
                     break;
                 }
 
-                keys[count] = key.clone();
+                // keys[count] = *k;
+                values[count] = data.clone();
                 // analog[count] = *val;
                 count += 1;
             }

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -3,8 +3,7 @@ mod delegate_sys;
 
 use crate::{
     AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
-    KeySource, KeycodeType, PhysicalKey, SDKResult, V2Data, ValueMetadata, WootingAnalogResult,
-    sdk::*,
+    KeycodeType, PhysicalKey, SDKResult, WootingAnalogResult, sdk::*,
 };
 #[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
@@ -198,19 +197,6 @@ pub extern "C" fn wooting_analog_read_analog(code: c_ushort) -> c_float {
     wooting_analog_read_analog_device(code, 0)
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn wooting_analog_read_analog_with_ctx(
-    key_source: *const KeySource,
-    value: *mut AnalogValue,
-) -> WootingAnalogResult {
-    #[cfg(feature = "dist")]
-    if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_analog_device_with_ctx(key_source, value, 0);
-    }
-
-    unsafe { wooting_analog_read_analog_device_with_ctx(key_source, value, 0) }
-}
-
 /// Reads the Analog value of the key with identifier `code` from the device with id `device_id`. The set of key identifiers that is used
 /// depends on the Keycode mode set using `wooting_analog_set_mode`.
 ///
@@ -241,37 +227,63 @@ pub extern "C" fn wooting_analog_read_analog_device(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wooting_analog_read_analog_device_with_ctx(
-    key_source: *const KeySource,
+pub unsafe extern "C" fn wooting_analog_read_keycode_device(
+    keycode: c_ushort,
     value: *mut AnalogValue,
     device_id: DeviceID,
 ) -> WootingAnalogResult {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_analog_device_with_ctx(
-            key_source, value, device_id,
-        );
+        return delegate_sys::wooting_analog_read_keycode_device(keycode, value, device_id);
     }
-
-    let Some(key_source) = (unsafe { key_source.as_ref() }) else {
-        return WootingAnalogResult::InvalidArgument;
-    };
 
     match ANALOG_SDK
         .lock()
         .unwrap()
-        .read_analog_with_ctx(*key_source, device_id)
+        .read_keycode(keycode, device_id)
         .0
     {
         Ok(v) => {
-            if let Some(out) = unsafe { value.as_mut() } {
-                *out = v;
-                return WootingAnalogResult::Ok;
-            }
-
-            WootingAnalogResult::InvalidArgument
+            let Some(out) = (unsafe { value.as_mut() }) else {
+                return WootingAnalogResult::InvalidArgument;
+            };
+            *out = v;
+            WootingAnalogResult::Ok
         }
         Err(e) => e,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wooting_analog_read_position_device(
+    position: *mut KeyPosition,
+    physical_key: *mut PhysicalKey,
+    device_id: DeviceID,
+) -> WootingAnalogResult {
+    #[cfg(feature = "dist")]
+    if *USE_SYS_DLL {
+        return delegate_sys::wooting_analog_read_position_device(
+            position,
+            physical_key,
+            device_id,
+        );
+    }
+
+    unsafe {
+        let Some(pos) = position.as_ref() else {
+            return WootingAnalogResult::InvalidArgument;
+        };
+
+        match ANALOG_SDK.lock().unwrap().read_position(*pos, device_id).0 {
+            Ok(pk) => {
+                let Some(out) = physical_key.as_mut() else {
+                    return WootingAnalogResult::InvalidArgument;
+                };
+                *out = pk;
+                WootingAnalogResult::Ok
+            }
+            Err(e) => e,
+        }
     }
 }
 
@@ -419,31 +431,6 @@ pub extern "C" fn wooting_analog_read_full_buffer(
     wooting_analog_read_full_buffer_device(code_buffer, analog_buffer, len, 0)
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx(
-    // code_buffer: *mut KeyCode,
-    // analog_buffer: *mut AnalogValue,
-    // physical_keys: *mut PhysicalKey,
-    // key_buffer: *mut V2DataKey,
-    data_buffer: *mut V2Data,
-    len: c_uint,
-) -> c_int {
-    #[cfg(feature = "dist")]
-    if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
-            // code_buffer,
-            // analog_buffer,
-            // physical_keys,
-            // key_buffer,
-            data_buffer,
-            len,
-            0,
-        );
-    }
-
-    unsafe { wooting_analog_read_full_buffer_device_with_ctx(data_buffer, len, 0) }
-}
-
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
 /// keycode identifying the pressed key and fills up `analog_buffer` with the corresponding float analog values. i.e. The analog
 /// value for they key at index 0 of code_buffer, is at index 0 of analog_buffer.
@@ -514,74 +501,81 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
-    // code_buffer: *mut KeyCode,
-    // analog_buffer: *mut AnalogValue,
+pub unsafe extern "C" fn wooting_analog_read_keycodes_device(
+    code_buffer: *mut KeyCode,
+    analog_buffer: *mut AnalogValue,
     // physical_keys: *mut PhysicalKey,
     // key_buffer: *mut V2DataKey,
-    data_buffer: *mut V2Data,
+    // data_buffer: *mut V2Data,
     len: c_uint,
     device_id: DeviceID,
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
-            // code_buffer,
-            // analog_buffer,
-            // physical_keys,
-            // key_buffer,
-            data_buffer,
+        return delegate_sys::wooting_analog_read_keycodes_device(
+            code_buffer,
+            analog_buffer,
             len,
             device_id,
         );
     }
 
-    // let codes = unsafe {
-    //     assert!(!code_buffer.is_null());
+    let codes = unsafe {
+        assert!(!code_buffer.is_null());
 
-    //     slice::from_raw_parts_mut(code_buffer, len as usize)
-    // };
-
-    // let analog = unsafe {
-    //     assert!(!analog_buffer.is_null());
-
-    //     slice::from_raw_parts_mut(analog_buffer, len as usize)
-    // };
-
-    // let keys = unsafe {
-    //     assert!(!physical_keys.is_null());
-
-    //     slice::from_raw_parts_mut(physical_keys, len as usize)
-    // };
-
-    // let keys = unsafe {
-    //     assert!(!key_buffer.is_null());
-
-    //     slice::from_raw_parts_mut(key_buffer, len as usize)
-    // };
-
-    let values = unsafe {
-        assert!(!data_buffer.is_null());
-
-        slice::from_raw_parts_mut(data_buffer, len as usize)
+        slice::from_raw_parts_mut(code_buffer, len as usize)
     };
 
-    match ANALOG_SDK
-        .lock()
-        .unwrap()
-        .read_full_buffer_with_ctx(len as usize, device_id)
-        .0
-    {
+    let analog = unsafe {
+        assert!(!analog_buffer.is_null());
+
+        slice::from_raw_parts_mut(analog_buffer, len as usize)
+    };
+
+    match ANALOG_SDK.lock().unwrap().read_keycodes(device_id).0 {
         Ok(analog_data) => {
             let mut count: usize = 0;
-            for data in analog_data.into_vec() {
-                if count >= values.len() {
+            for (k, v) in analog_data {
+                if count >= codes.len() {
                     break;
                 }
 
-                // keys[count] = *k;
-                values[count] = data.clone();
-                // analog[count] = *val;
+                codes[count] = k;
+                analog[count] = v;
+                count += 1;
+            }
+            count as c_int
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wooting_analog_read_positions_device(
+    physical_keys: *mut PhysicalKey,
+    len: c_uint,
+    device_id: DeviceID,
+) -> c_int {
+    #[cfg(feature = "dist")]
+    if *USE_SYS_DLL {
+        return delegate_sys::wooting_analog_read_positions_device(physical_keys, len, device_id);
+    }
+
+    let keys = unsafe {
+        assert!(!physical_keys.is_null());
+
+        slice::from_raw_parts_mut(physical_keys, len as usize)
+    };
+
+    match ANALOG_SDK.lock().unwrap().read_positions(device_id).0 {
+        Ok(analog_data) => {
+            let mut count: usize = 0;
+            for (_, k) in analog_data {
+                if count >= keys.len() {
+                    break;
+                }
+
+                keys[count] = k;
                 count += 1;
             }
             count as c_int

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -2,8 +2,8 @@
 mod delegate_sys;
 
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeySource, KeycodeType,
-    Position, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeySource,
+    KeycodeType, Position, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*,
 };
 #[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
@@ -403,6 +403,25 @@ pub extern "C" fn wooting_analog_read_full_buffer(
     wooting_analog_read_full_buffer_device(code_buffer, analog_buffer, len, 0)
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx(
+    code_buffer: *mut KeyCode,
+    analog_buffer: *mut AnalogValue,
+    len: c_uint,
+) -> c_int {
+    #[cfg(feature = "dist")]
+    if *USE_SYS_DLL {
+        return delegate_sys::wooting_analog_read_full_buffer_with_ctx_device(
+            code_buffer,
+            analog_buffer,
+            len,
+            0,
+        );
+    }
+
+    unsafe { wooting_analog_read_full_buffer_with_ctx_device(code_buffer, analog_buffer, len, 0) }
+}
+
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
 /// keycode identifying the pressed key and fills up `analog_buffer` with the corresponding float analog values. i.e. The analog
 /// value for they key at index 0 of code_buffer, is at index 0 of analog_buffer.
@@ -452,6 +471,59 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
         .lock()
         .unwrap()
         .read_full_buffer(len as usize, device_id)
+        .0
+    {
+        Ok(analog_data) => {
+            //Fill up given slices
+            let mut count: usize = 0;
+            for (code, val) in analog_data.iter() {
+                if count >= codes.len() {
+                    break;
+                }
+
+                codes[count] = *code;
+                analog[count] = *val;
+                count += 1;
+            }
+            count as c_int
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx_device(
+    code_buffer: *mut KeyCode,
+    analog_buffer: *mut AnalogValue,
+    len: c_uint,
+    device_id: DeviceID,
+) -> c_int {
+    #[cfg(feature = "dist")]
+    if *USE_SYS_DLL {
+        return delegate_sys::wooting_analog_read_full_buffer_with_ctx_device(
+            code_buffer,
+            analog_buffer,
+            len,
+            device_id,
+        );
+    }
+
+    let codes = unsafe {
+        assert!(!code_buffer.is_null());
+
+        slice::from_raw_parts_mut(code_buffer, len as usize)
+    };
+
+    let analog = unsafe {
+        assert!(!analog_buffer.is_null());
+
+        slice::from_raw_parts_mut(analog_buffer, len as usize)
+    };
+
+    match ANALOG_SDK
+        .lock()
+        .unwrap()
+        .read_full_buffer_with_ctx(len as usize, device_id)
         .0
     {
         Ok(analog_data) => {

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -2,8 +2,7 @@
 mod delegate_sys;
 
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
-    KeySource, KeycodeType, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition, KeySource, KeycodeType, PhysicalKey, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*
 };
 #[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
@@ -420,21 +419,23 @@ pub extern "C" fn wooting_analog_read_full_buffer(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx(
-    code_buffer: *mut KeyCode,
-    analog_buffer: *mut AnalogValue,
+    // code_buffer: *mut KeyCode,
+    // analog_buffer: *mut AnalogValue,
+    physical_keys: *mut PhysicalKey,
     len: c_uint,
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
-            code_buffer,
-            analog_buffer,
+            // code_buffer,
+            // analog_buffer,
+            physical_keys,
             len,
             0,
         );
     }
 
-    unsafe { wooting_analog_read_full_buffer_device_with_ctx(code_buffer, analog_buffer, len, 0) }
+    unsafe { wooting_analog_read_full_buffer_device_with_ctx(physical_keys, len, 0) }
 }
 
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
@@ -508,31 +509,39 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
-    code_buffer: *mut KeyCode,
-    analog_buffer: *mut AnalogValue,
+    // code_buffer: *mut KeyCode,
+    // analog_buffer: *mut AnalogValue,
+    physical_keys: *mut PhysicalKey,
     len: c_uint,
     device_id: DeviceID,
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
         return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
-            code_buffer,
-            analog_buffer,
+            // code_buffer,
+            // analog_buffer,
+            physical_keys,
             len,
             device_id,
         );
     }
 
-    let codes = unsafe {
-        assert!(!code_buffer.is_null());
+    // let codes = unsafe {
+    //     assert!(!code_buffer.is_null());
 
-        slice::from_raw_parts_mut(code_buffer, len as usize)
-    };
+    //     slice::from_raw_parts_mut(code_buffer, len as usize)
+    // };
 
-    let analog = unsafe {
-        assert!(!analog_buffer.is_null());
+    // let analog = unsafe {
+    //     assert!(!analog_buffer.is_null());
 
-        slice::from_raw_parts_mut(analog_buffer, len as usize)
+    //     slice::from_raw_parts_mut(analog_buffer, len as usize)
+    // };
+
+    let keys = unsafe {
+        assert!(!physical_keys.is_null());
+
+        slice::from_raw_parts_mut(physical_keys, len as usize)
     };
 
     match ANALOG_SDK
@@ -544,13 +553,13 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
         Ok(analog_data) => {
             //Fill up given slices
             let mut count: usize = 0;
-            for (code, val) in analog_data.iter() {
-                if count >= codes.len() {
+            for key in analog_data.iter() {
+                if count >= keys.len() {
                     break;
                 }
 
-                codes[count] = *code;
-                analog[count] = *val;
+                keys[count] = key.clone();
+                // analog[count] = *val;
                 count += 1;
             }
             count as c_int

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -2,8 +2,8 @@
 mod delegate_sys;
 
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeySource,
-    KeycodeType, Position, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
+    KeySource, KeycodeType, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*,
 };
 #[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
@@ -191,13 +191,12 @@ pub extern "C" fn wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalog
 pub extern "C" fn wooting_analog_read_analog(code: c_ushort) -> c_float {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_analog(code);
+        return delegate_sys::wooting_analog_read_analog_device(code, 0);
     }
 
     wooting_analog_read_analog_device(code, 0)
 }
 
-// TODO: wooting_analog_read_analog_with_ctx_device ?
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wooting_analog_read_analog_with_ctx(
     key_source: *const KeySource,
@@ -205,29 +204,10 @@ pub unsafe extern "C" fn wooting_analog_read_analog_with_ctx(
 ) -> WootingAnalogResult {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_analog_with_ctx(key_source, value);
+        return delegate_sys::wooting_analog_read_analog_device_with_ctx(key_source, value, 0);
     }
 
-    let Some(key_source) = (unsafe { key_source.as_ref() }) else {
-        return WootingAnalogResult::InvalidArgument;
-    };
-
-    match ANALOG_SDK
-        .lock()
-        .unwrap()
-        .read_analog_with_ctx(*key_source, 0)
-        .0
-    {
-        Ok(v) => {
-            if let Some(out) = unsafe { value.as_mut() } {
-                *out = v;
-                return WootingAnalogResult::Ok;
-            }
-
-            WootingAnalogResult::InvalidArgument
-        }
-        Err(e) => e,
-    }
+    unsafe { wooting_analog_read_analog_device_with_ctx(key_source, value, 0) }
 }
 
 /// Reads the Analog value of the key with identifier `code` from the device with id `device_id`. The set of key identifiers that is used
@@ -257,6 +237,41 @@ pub extern "C" fn wooting_analog_read_analog_device(
         .unwrap()
         .read_analog(code, device_id)
         .into()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wooting_analog_read_analog_device_with_ctx(
+    key_source: *const KeySource,
+    value: *mut AnalogValue,
+    device_id: DeviceID,
+) -> WootingAnalogResult {
+    #[cfg(feature = "dist")]
+    if *USE_SYS_DLL {
+        return delegate_sys::wooting_analog_read_analog_device_with_ctx(
+            key_source, value, device_id,
+        );
+    }
+
+    let Some(key_source) = (unsafe { key_source.as_ref() }) else {
+        return WootingAnalogResult::InvalidArgument;
+    };
+
+    match ANALOG_SDK
+        .lock()
+        .unwrap()
+        .read_analog_with_ctx(*key_source, device_id)
+        .0
+    {
+        Ok(v) => {
+            if let Some(out) = unsafe { value.as_mut() } {
+                *out = v;
+                return WootingAnalogResult::Ok;
+            }
+
+            WootingAnalogResult::InvalidArgument
+        }
+        Err(e) => e,
+    }
 }
 
 /// Set the callback which is called when there is a DeviceEvent. Currently these events can either be Disconnected or Connected(Currently not properly implemented).
@@ -411,7 +426,7 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx(
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_full_buffer_with_ctx_device(
+        return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
             code_buffer,
             analog_buffer,
             len,
@@ -419,7 +434,7 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx(
         );
     }
 
-    unsafe { wooting_analog_read_full_buffer_with_ctx_device(code_buffer, analog_buffer, len, 0) }
+    unsafe { wooting_analog_read_full_buffer_device_with_ctx(code_buffer, analog_buffer, len, 0) }
 }
 
 /// Reads all the analog values for pressed keys for the device with id `device_id`, filling up `code_buffer` with the
@@ -492,7 +507,7 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx_device(
+pub unsafe extern "C" fn wooting_analog_read_full_buffer_device_with_ctx(
     code_buffer: *mut KeyCode,
     analog_buffer: *mut AnalogValue,
     len: c_uint,
@@ -500,7 +515,7 @@ pub unsafe extern "C" fn wooting_analog_read_full_buffer_with_ctx_device(
 ) -> c_int {
     #[cfg(feature = "dist")]
     if *USE_SYS_DLL {
-        return delegate_sys::wooting_analog_read_full_buffer_with_ctx_device(
+        return delegate_sys::wooting_analog_read_full_buffer_device_with_ctx(
             code_buffer,
             analog_buffer,
             len,

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -2,8 +2,8 @@
 mod delegate_sys;
 
 use crate::{
-    DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeycodeType, SDKResult,
-    WootingAnalogResult, sdk::*,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeySource, KeycodeType,
+    Position, SDKResult, ValueMetadata, WootingAnalogResult, sdk::*,
 };
 #[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
@@ -195,6 +195,39 @@ pub extern "C" fn wooting_analog_read_analog(code: c_ushort) -> c_float {
     }
 
     wooting_analog_read_analog_device(code, 0)
+}
+
+// TODO: wooting_analog_read_analog_with_ctx_device ?
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wooting_analog_read_analog_with_ctx(
+    key_source: *const KeySource,
+    value: *mut AnalogValue,
+) -> WootingAnalogResult {
+    #[cfg(feature = "dist")]
+    if *USE_SYS_DLL {
+        return delegate_sys::wooting_analog_read_analog_with_ctx(key_source, value);
+    }
+
+    let Some(key_source) = (unsafe { key_source.as_ref() }) else {
+        return WootingAnalogResult::InvalidArgument;
+    };
+
+    match ANALOG_SDK
+        .lock()
+        .unwrap()
+        .read_analog_with_ctx(*key_source, 0)
+        .0
+    {
+        Ok(v) => {
+            if let Some(out) = unsafe { value.as_mut() } {
+                *out = v;
+                return WootingAnalogResult::Ok;
+            }
+
+            WootingAnalogResult::InvalidArgument
+        }
+        Err(e) => e,
+    }
 }
 
 /// Reads the Analog value of the key with identifier `code` from the device with id `device_id`. The set of key identifiers that is used
@@ -442,8 +475,12 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
 #[unsafe(no_mangle)]
 pub extern "C" fn wooting_analog_using_sys() -> bool {
     #[cfg(feature = "dist")]
-    { *USE_SYS_DLL }
+    {
+        *USE_SYS_DLL
+    }
 
     #[cfg(not(feature = "dist"))]
-    { true }
+    {
+        true
+    }
 }

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeyCode, KeySource, PhysicalKey, WootingAnalogResult
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeySource, V2Data, WootingAnalogResult,
 };
 use libloading::Symbol;
 use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};
@@ -159,7 +159,9 @@ delegate_sys! {
     wooting_analog_read_full_buffer_device_with_ctx(
         // code_buffer: *mut KeyCode,
         // analog_buffer: *mut AnalogValue,
-        physical_keys: *mut PhysicalKey,
+        // physical_keys: *mut PhysicalKey,
+        // key_buffer: *mut V2DataKey,
+        data_buffer: *mut V2Data,
         len: c_uint,
         device_id: DeviceID
     ) -> c_int;

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,4 +1,6 @@
-use crate::{DeviceEventType, DeviceID, DeviceInfo_FFI, WootingAnalogResult};
+use crate::{
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeySource, WootingAnalogResult,
+};
 use libloading::Symbol;
 use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};
 use std::path::{Path, PathBuf};
@@ -135,6 +137,7 @@ delegate_sys! {
     wooting_analog_uninitialise() -> WootingAnalogResult;
     wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult;
     wooting_analog_read_analog(code: c_ushort) -> c_float;
+    wooting_analog_read_analog_with_ctx(key_source: *const KeySource, value: *mut AnalogValue) -> WootingAnalogResult;
     wooting_analog_read_analog_device(code: c_ushort, device_id: DeviceID) -> c_float;
     wooting_analog_set_device_event_cb(
         cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI)

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeySource, V2Data, WootingAnalogResult,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeyCode, KeyPosition, PhysicalKey,
+    WootingAnalogResult,
 };
 use libloading::Symbol;
 use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};
@@ -137,9 +138,14 @@ delegate_sys! {
     wooting_analog_uninitialise() -> WootingAnalogResult;
     wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult;
     wooting_analog_read_analog_device(code: c_ushort, device_id: DeviceID) -> c_float;
-    wooting_analog_read_analog_device_with_ctx(
-        key_source: *const KeySource,
+    wooting_analog_read_keycode_device(
+        keycode: c_ushort,
         value: *mut AnalogValue,
+        device_id: DeviceID
+    ) -> WootingAnalogResult;
+    wooting_analog_read_position_device(
+        position: *mut KeyPosition,
+        physical_key: *mut PhysicalKey,
         device_id: DeviceID
     ) -> WootingAnalogResult;
     wooting_analog_set_device_event_cb(
@@ -156,12 +162,14 @@ delegate_sys! {
         len: c_uint,
         device_id: DeviceID
     ) -> c_int;
-    wooting_analog_read_full_buffer_device_with_ctx(
-        // code_buffer: *mut KeyCode,
-        // analog_buffer: *mut AnalogValue,
-        // physical_keys: *mut PhysicalKey,
-        // key_buffer: *mut V2DataKey,
-        data_buffer: *mut V2Data,
+    wooting_analog_read_keycodes_device(
+        code_buffer: *mut KeyCode,
+        analog_buffer: *mut AnalogValue,
+        len: c_uint,
+        device_id: DeviceID
+    ) -> c_int;
+    wooting_analog_read_positions_device(
+        physical_keys: *mut PhysicalKey,
         len: c_uint,
         device_id: DeviceID
     ) -> c_int;

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeyCode, KeySource, WootingAnalogResult,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeyCode, KeySource, PhysicalKey, WootingAnalogResult
 };
 use libloading::Symbol;
 use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};
@@ -157,8 +157,9 @@ delegate_sys! {
         device_id: DeviceID
     ) -> c_int;
     wooting_analog_read_full_buffer_device_with_ctx(
-        code_buffer: *mut KeyCode,
-        analog_buffer: *mut AnalogValue,
+        // code_buffer: *mut KeyCode,
+        // analog_buffer: *mut AnalogValue,
+        physical_keys: *mut PhysicalKey,
         len: c_uint,
         device_id: DeviceID
     ) -> c_int;

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeySource, WootingAnalogResult,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeyCode, KeySource, WootingAnalogResult,
 };
 use libloading::Symbol;
 use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};
@@ -137,7 +137,10 @@ delegate_sys! {
     wooting_analog_uninitialise() -> WootingAnalogResult;
     wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult;
     wooting_analog_read_analog(code: c_ushort) -> c_float;
-    wooting_analog_read_analog_with_ctx(key_source: *const KeySource, value: *mut AnalogValue) -> WootingAnalogResult;
+    wooting_analog_read_analog_with_ctx(
+        key_source: *const KeySource,
+        value: *mut AnalogValue
+    ) -> WootingAnalogResult;
     wooting_analog_read_analog_device(code: c_ushort, device_id: DeviceID) -> c_float;
     wooting_analog_set_device_event_cb(
         cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI)
@@ -150,6 +153,12 @@ delegate_sys! {
     wooting_analog_read_full_buffer_device(
         code_buffer: *mut c_ushort,
         analog_buffer: *mut c_float,
+        len: c_uint,
+        device_id: DeviceID
+    ) -> c_int;
+    wooting_analog_read_full_buffer_with_ctx_device(
+        code_buffer: *mut KeyCode,
+        analog_buffer: *mut AnalogValue,
         len: c_uint,
         device_id: DeviceID
     ) -> c_int;

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -136,12 +136,12 @@ delegate_sys! {
     wooting_analog_is_initialised() -> bool;
     wooting_analog_uninitialise() -> WootingAnalogResult;
     wooting_analog_set_keycode_mode(mode: c_uint) -> WootingAnalogResult;
-    wooting_analog_read_analog(code: c_ushort) -> c_float;
-    wooting_analog_read_analog_with_ctx(
-        key_source: *const KeySource,
-        value: *mut AnalogValue
-    ) -> WootingAnalogResult;
     wooting_analog_read_analog_device(code: c_ushort, device_id: DeviceID) -> c_float;
+    wooting_analog_read_analog_device_with_ctx(
+        key_source: *const KeySource,
+        value: *mut AnalogValue,
+        device_id: DeviceID
+    ) -> WootingAnalogResult;
     wooting_analog_set_device_event_cb(
         cb: extern "C" fn(DeviceEventType, *mut DeviceInfo_FFI)
     ) -> WootingAnalogResult;
@@ -156,7 +156,7 @@ delegate_sys! {
         len: c_uint,
         device_id: DeviceID
     ) -> c_int;
-    wooting_analog_read_full_buffer_with_ctx_device(
+    wooting_analog_read_full_buffer_device_with_ctx(
         code_buffer: *mut KeyCode,
         analog_buffer: *mut AnalogValue,
         len: c_uint,

--- a/wooting-analog-sdk/src/keycode.rs
+++ b/wooting-analog-sdk/src/keycode.rs
@@ -216,13 +216,13 @@ static HID_TO_VK_MAP_US: LazyLock<BiMap<u8, u8>> = LazyLock::new(|| {
     bimap.insert(0x26, 0x39); // DIGIT9
     bimap.insert(0x27, 0x30); // DIGIT0
 
-        bimap.insert(0x29, 0x1B); // ESCAPE
-        bimap.insert(0x2a, 0x08); // BACKSPACE
-        bimap.insert(0x2b, 0x09); // TAB
-        bimap.insert(0x2c, 0x20); // SPACE
-        bimap.insert(0x2d, 0xBD); // MINUS
-        bimap.insert(0x2e, 0xBB); // EQUAL
-        bimap.insert(0x2f, 0xDB); // BRACKET_LEFT
+    bimap.insert(0x29, 0x1B); // ESCAPE
+    bimap.insert(0x2a, 0x08); // BACKSPACE
+    bimap.insert(0x2b, 0x09); // TAB
+    bimap.insert(0x2c, 0x20); // SPACE
+    bimap.insert(0x2d, 0xBD); // MINUS
+    bimap.insert(0x2e, 0xBB); // EQUAL
+    bimap.insert(0x2f, 0xDB); // BRACKET_LEFT
 
     bimap.insert(0x30, 0xDD); // BRACKET_RIGHT
     bimap.insert(0x31, 0xDC); // BACKSLASH
@@ -266,24 +266,24 @@ static HID_TO_VK_MAP_US: LazyLock<BiMap<u8, u8>> = LazyLock::new(|| {
     bimap.insert(0x52, 0x26); // ARROW_UP
 
     bimap.insert(0x53, 0x90); // NUM_LOCK
-        bimap.insert(0x54, 0x6F); // NUMPAD_DIVIDE
-        bimap.insert(0x55, 0x6A); // NUMPAD_MULTIPLY
-        bimap.insert(0x56, 0x6D); // NUMPAD_SUBTRACT
-        bimap.insert(0x57, 0x6B); // NUMPAD_ADD
-        bimap.insert(0x58, 0x0D); // NUMPAD_ENTER
-        bimap.insert(0x59, 0x61); // NUMPAD1
-        bimap.insert(0x5a, 0x62); // NUMPAD2
-        bimap.insert(0x5b, 0x63); // NUMPAD3
-        bimap.insert(0x5c, 0x64); // NUMPAD4
-        bimap.insert(0x5d, 0x65); // NUMPAD5
-        bimap.insert(0x5e, 0x66); // NUMPAD6
-        bimap.insert(0x5f, 0x67); // NUMPAD7
-        bimap.insert(0x60, 0x68); // NUMPAD8
-        bimap.insert(0x61, 0x69); // NUMPAD9
-        bimap.insert(0x62, 0x60); // NUMPAD0
-        bimap.insert(0x63, 0x6E); // NUMPAD_DECIMAL
+    bimap.insert(0x54, 0x6F); // NUMPAD_DIVIDE
+    bimap.insert(0x55, 0x6A); // NUMPAD_MULTIPLY
+    bimap.insert(0x56, 0x6D); // NUMPAD_SUBTRACT
+    bimap.insert(0x57, 0x6B); // NUMPAD_ADD
+    bimap.insert(0x58, 0x0D); // NUMPAD_ENTER
+    bimap.insert(0x59, 0x61); // NUMPAD1
+    bimap.insert(0x5a, 0x62); // NUMPAD2
+    bimap.insert(0x5b, 0x63); // NUMPAD3
+    bimap.insert(0x5c, 0x64); // NUMPAD4
+    bimap.insert(0x5d, 0x65); // NUMPAD5
+    bimap.insert(0x5e, 0x66); // NUMPAD6
+    bimap.insert(0x5f, 0x67); // NUMPAD7
+    bimap.insert(0x60, 0x68); // NUMPAD8
+    bimap.insert(0x61, 0x69); // NUMPAD9
+    bimap.insert(0x62, 0x60); // NUMPAD0
+    bimap.insert(0x63, 0x6E); // NUMPAD_DECIMAL
 
-        bimap.insert(0x28, 0x0D); // ENTER (moved below NUMPAD_ENTER to ensure vk_to_hid(0x0D) responds with 0x28 instead of 0x58)
+    bimap.insert(0x28, 0x0D); // ENTER (moved below NUMPAD_ENTER to ensure vk_to_hid(0x0D) responds with 0x28 instead of 0x58)
 
     bimap.insert(0x64, 0xE2); // INTL_BACKSLASH
     bimap.insert(0x65, 0x5D); // CONTEXT_MENU
@@ -441,7 +441,12 @@ pub fn code_to_hid(code: u16, mode: &KeycodeType) -> Option<u16> {
     }
 }
 
-pub fn hid_to_code(code: u16, mode: &KeycodeType) -> Option<u16> {
+pub fn hid_to_code<T>(code: T, mode: &KeycodeType) -> Option<u16>
+where
+    T: Into<u16>,
+{
+    let code = code.into();
+
     let prefix = (code & 0xFF00) >> 8;
     //Check if the code is a custom key, if it is, just straight return it. Additionally checking it isn't prefixed with the ScanCode 1 escape code
     if code >= 0x200 && prefix != 0xE0 {

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -12,6 +12,7 @@ use ffi_support::FfiStr;
 pub use num_traits::{FromPrimitive, ToPrimitive};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::hash::Hasher;
 use std::ops::Deref;
@@ -152,14 +153,6 @@ impl DeviceInfo {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[repr(C, u8)]
-pub enum KeySource {
-    Raw(u16),
-    Code(KeyCode),
-    Position(KeyPosition),
-}
-
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone, Primitive)]
 #[repr(C)]
@@ -211,8 +204,8 @@ pub enum KeyMetadata {
 #[derive(Copy, Clone, Eq, Debug, Default)]
 #[repr(C)]
 pub struct KeyCode {
-    inner: u16,
-    metadata: KeyMetadata,
+    pub(crate) inner: u16,
+    pub(crate) metadata: KeyMetadata,
 }
 
 impl KeyCode {
@@ -295,18 +288,6 @@ pub enum ValueMetadata {
     },
 }
 
-// struct V2 {}
-
-// #[repr(C, u8)]
-// enum V2T {
-//     V1 { code: u16, value: f32 },
-//     V2(V2),
-//     // NO ADDING
-// }
-
-// fn v1_api() -> (u16, f32) {todo!()}
-// fn v2_api() -> V2T {todo!()}
-
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[repr(C)]
 pub struct KeyPosition {
@@ -376,19 +357,10 @@ impl From<f32> for AnalogValue {
     }
 }
 
-use std::collections::HashMap;
-
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
-#[repr(C, u8)]
-pub enum V2Data {
-    V1 { keycode: u16, value: f32 },
-    V2(PhysicalKey),
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct AnalogData {
-    v1: HashMap<u16, f32>,
-    v2: HashMap<KeyPosition, PhysicalKey>,
+    keycode_based: HashMap<KeyCode, AnalogValue>,
+    position_based: HashMap<KeyPosition, PhysicalKey>,
 }
 
 impl AnalogData {
@@ -396,77 +368,84 @@ impl AnalogData {
         Self::default()
     }
 
-    pub fn with_capacity(v1_capacity: usize, v2_capacity: usize) -> Self {
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            v1: HashMap::with_capacity(v1_capacity),
-            v2: HashMap::with_capacity(v2_capacity),
+            keycode_based: HashMap::with_capacity(capacity),
+            position_based: HashMap::with_capacity(capacity),
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.v1.is_empty() && self.v2.is_empty()
+        self.keycode_based.is_empty() && self.position_based.is_empty()
     }
 
     pub fn len(&self) -> usize {
-        self.v1.len() + self.v2.len()
+        self.keycode_based.len() + self.position_based.len()
     }
 
-    pub fn insert_v1(&mut self, keycode: u16, value: f32) {
-        self.v1
-            .entry(keycode)
-            .and_modify(|existing| *existing = existing.max(value))
+    pub fn insert_keycode_based(&mut self, code: KeyCode, value: AnalogValue) {
+        self.keycode_based
+            .entry(code)
+            .and_modify(|existing| {
+                if &value > existing {
+                    *existing = value;
+                }
+            })
             .or_insert(value);
     }
 
-    pub fn insert_v2(&mut self, pk: PhysicalKey) {
-        self.v2
-            .entry(pk.pos)
+    pub fn insert_position_based(&mut self, physical_key: PhysicalKey) {
+        self.position_based
+            .entry(physical_key.pos)
             .and_modify(|existing| {
-                if pk.max_value() > existing.max_value() {
-                    *existing = pk;
+                if physical_key.max_value() > existing.max_value() {
+                    *existing = physical_key;
                 }
             })
-            .or_insert(pk);
+            .or_insert(physical_key);
     }
 
-    pub(crate) fn push_v2_state(&mut self, pos: KeyPosition, state: KeyState) {
-        self.v2
-            .entry(pos)
+    pub(crate) fn push_v2_state(&mut self, position: KeyPosition, state: KeyState) {
+        self.position_based
+            .entry(position)
             .and_modify(|existing| {
                 existing.push_state(state);
             })
             .or_insert_with(|| {
-                let mut pk = PhysicalKey::new(pos);
+                let mut pk = PhysicalKey::new(position);
                 pk.push_state(state);
                 pk
             });
     }
 
     pub fn merge(&mut self, other: AnalogData) {
-        for (keycode, value) in other.v1 {
-            self.insert_v1(keycode, value);
+        for (keycode, value) in other.keycode_based {
+            self.insert_keycode_based(keycode, value);
         }
-        for (_, pk) in other.v2 {
-            self.insert_v2(pk);
+        for (_, pk) in other.position_based {
+            self.insert_position_based(pk);
         }
     }
+}
 
-    pub fn iter(&self) -> impl Iterator<Item = V2Data> + '_ {
-        self.v1
-            .iter()
-            .map(|(&keycode, &value)| V2Data::V1 { keycode, value })
-            .chain(self.v2.values().cloned().map(V2Data::V2))
-    }
+impl From<Vec<Key>> for AnalogData {
+    fn from(keys: Vec<Key>) -> Self {
+        let mut data = Self::new();
 
-    // TODO: for performance return iterator instead since FFI will iterate over these anyway to
-    // copy them into the raw V2Data pointer. could make this function pub(crate) so only our FFI
-    // functions can use it, feels like it wouldn't be useful for rust side anyway.
-    pub fn into_vec(self) -> Vec<V2Data> {
-        self.v1
-            .into_iter()
-            .map(|(keycode, value)| V2Data::V1 { keycode, value })
-            .chain(self.v2.into_values().map(V2Data::V2))
-            .collect()
+        for key in keys {
+            if let ValueMetadata::Basic { pos, actuated } = key.value.metadata {
+                let key_state = KeyState {
+                    value: key.value.inner,
+                    keycode: key.code,
+                    actuated,
+                };
+                data.push_v2_state(pos, key_state);
+            }
+
+            data.insert_keycode_based(key.code, key.value);
+        }
+
+        data
     }
 }
 
@@ -524,6 +503,10 @@ impl PhysicalKey {
 
     pub(crate) fn max_value(&self) -> f32 {
         self.states().iter().map(|s| s.value).fold(0.0, f32::max)
+    }
+
+    pub(crate) fn is_advanced_key(&self) -> bool {
+        self.states.iter().any(|s| s.keycode.is_advanced_key())
     }
 }
 

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -155,7 +155,7 @@ impl DeviceInfo {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[repr(C, u8)]
 pub enum KeySource {
-    Code(u16),
+    Raw(u16),
     Position(Position),
 }
 
@@ -240,6 +240,12 @@ impl From<u16> for KeyCode {
             inner: value,
             metadata: KeyMetadata::None,
         }
+    }
+}
+
+impl From<KeyCode> for u16 {
+    fn from(value: KeyCode) -> Self {
+        value.inner
     }
 }
 
@@ -392,7 +398,7 @@ pub enum WootingAnalogResult {
     /// Indicates that the Analog SDK could not be found on the system
     #[error("The Wooting Analog SDK could not be found on the system")]
     DLLNotFound = -1990isize,
-    /// Device does not have the required analog protocol 
+    /// Device does not have the required analog protocol
     #[error("The device does not have the required analog protocol")]
     IncompatibleAnalogProtocol = -1989isize,
 }

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -2,9 +2,9 @@
 pub mod ffi;
 pub mod keycode;
 mod plugin;
+pub mod sdk;
 #[cfg(feature = "virtual-input")]
 mod virtual_input;
-pub mod sdk;
 
 pub use crate::plugin::Plugin;
 use enum_primitive_derive::Primitive;
@@ -152,6 +152,13 @@ impl DeviceInfo {
     }
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[repr(C, u8)]
+pub enum KeySource {
+    Code(u16),
+    Position(Position),
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Clone, Primitive)]
 #[repr(C)]
@@ -167,6 +174,7 @@ pub enum KeycodeType {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(C, u8)]
 pub enum KeyMetadata {
     #[default]
     None,
@@ -176,6 +184,7 @@ pub enum KeyMetadata {
 }
 
 #[derive(Copy, Clone, Eq, Debug, Default)]
+#[repr(C)]
 pub struct KeyCode {
     inner: u16,
     metadata: KeyMetadata,
@@ -235,6 +244,7 @@ impl From<u16> for KeyCode {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(C, u8)]
 pub enum ValueMetadata {
     #[default]
     None,
@@ -245,6 +255,7 @@ pub enum ValueMetadata {
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(C)]
 pub struct Position {
     x: u8,
     y: u8,
@@ -256,7 +267,9 @@ impl Position {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default)]
+// TODO: check all comparison impls
+#[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
+#[repr(C)]
 pub struct AnalogValue {
     inner: f32,
     metadata: ValueMetadata,
@@ -281,23 +294,23 @@ impl AnalogValue {
     }
 }
 
-impl PartialEq for AnalogValue {
-    fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
-    }
-}
-
 impl Eq for AnalogValue {}
-
-impl PartialOrd for AnalogValue {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
 
 impl Ord for AnalogValue {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.inner.total_cmp(&other.inner)
+    }
+}
+
+impl PartialEq<f32> for AnalogValue {
+    fn eq(&self, other: &f32) -> bool {
+        &self.inner == other
+    }
+}
+
+impl PartialOrd<f32> for AnalogValue {
+    fn partial_cmp(&self, other: &f32) -> Option<std::cmp::Ordering> {
+        self.inner.partial_cmp(other)
     }
 }
 
@@ -379,6 +392,9 @@ pub enum WootingAnalogResult {
     /// Indicates that the Analog SDK could not be found on the system
     #[error("The Wooting Analog SDK could not be found on the system")]
     DLLNotFound = -1990isize,
+    /// Device does not have the required analog protocol 
+    #[error("The device does not have the required analog protocol")]
+    IncompatibleAnalogProtocol = -1989isize,
 }
 
 impl WootingAnalogResult {

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -363,6 +363,8 @@ pub struct AnalogData {
     position_based: HashMap<KeyPosition, PhysicalKey>,
 }
 
+// everything on this struct is pub but most likely this will be an internal type only
+// i'll leave it for now but in the next PR this will all be hidden away properly
 impl AnalogData {
     pub fn new() -> Self {
         Self::default()
@@ -405,7 +407,7 @@ impl AnalogData {
             .or_insert(physical_key);
     }
 
-    pub(crate) fn push_v2_state(&mut self, position: KeyPosition, state: KeyState) {
+    pub fn push_v2_state(&mut self, position: KeyPosition, state: KeyState) {
         self.position_based
             .entry(position)
             .and_modify(|existing| {

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -295,6 +295,18 @@ pub enum ValueMetadata {
     },
 }
 
+// struct V2 {}
+
+// #[repr(C, u8)]
+// enum V2T {
+//     V1 { code: u16, value: f32 },
+//     V2(V2),
+//     // NO ADDING
+// }
+
+// fn v1_api() -> (u16, f32) {todo!()}
+// fn v2_api() -> V2T {todo!()}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[repr(C)]
 pub struct KeyPosition {
@@ -312,8 +324,8 @@ impl KeyPosition {
 #[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
 #[repr(C)]
 pub struct AnalogValue {
-    inner: f32,
-    metadata: ValueMetadata,
+    pub(crate) inner: f32,
+    pub(crate) metadata: ValueMetadata,
 }
 
 impl AnalogValue {
@@ -362,6 +374,71 @@ impl From<f32> for AnalogValue {
             metadata: ValueMetadata::None,
         }
     }
+}
+
+// should not be publicly accessible
+#[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
+#[repr(C)]
+pub(crate) struct Key {
+    pub(crate) code: KeyCode,
+    pub(crate) value: AnalogValue,
+}
+
+/// Maximum number of active binds per physical key (DKS has 4 underlying binds + advanced key entry)
+pub const MAX_KEY_STATES: u8 = 5;
+
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+#[repr(C)]
+pub struct PhysicalKey {
+    pub(crate) pos: KeyPosition,
+    pub(crate) state_count: u8,
+    pub(crate) states: [KeyState; MAX_KEY_STATES as usize],
+}
+
+impl Default for PhysicalKey {
+    fn default() -> Self {
+        Self {
+            pos: KeyPosition::default(),
+            state_count: 0,
+            states: [KeyState::default(); MAX_KEY_STATES as usize],
+        }
+    }
+}
+
+impl PhysicalKey {
+    pub(crate) fn new(pos: KeyPosition) -> Self {
+        Self {
+            pos,
+            state_count: 0,
+            states: [KeyState::default(); MAX_KEY_STATES as usize],
+        }
+    }
+
+    pub(crate) fn push_state(&mut self, state: KeyState) -> bool {
+        if self.state_count < MAX_KEY_STATES {
+            self.states[self.state_count as usize] = state;
+            self.state_count += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn states(&self) -> &[KeyState] {
+        &self.states[..self.state_count as usize]
+    }
+
+    pub(crate) fn max_value(&self) -> f32 {
+        self.states().iter().map(|s| s.value).fold(0.0, f32::max)
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
+#[repr(C)]
+pub struct KeyState {
+    pub(crate) value: f32,
+    pub(crate) keycode: KeyCode,
+    pub(crate) actuated: bool,
 }
 
 pub type DeviceID = u64;

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -156,7 +156,8 @@ impl DeviceInfo {
 #[repr(C, u8)]
 pub enum KeySource {
     Raw(u16),
-    Position(Position),
+    Code(KeyCode),
+    Position(KeyPosition),
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -173,13 +174,37 @@ pub enum KeycodeType {
     VirtualKeyTranslate = 3,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[repr(C)]
+pub enum KeyNamespace {
+    HidNormal = 1,
+    HidFunction = 3,
+    CustomFunction = 4,
+    GamepadBinding = 5,
+    AdvancedKey = 6,
+}
+
+impl From<u8> for KeyNamespace {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => KeyNamespace::HidNormal,
+            3 => KeyNamespace::HidFunction,
+            4 => KeyNamespace::CustomFunction,
+            5 => KeyNamespace::GamepadBinding,
+            6 => KeyNamespace::AdvancedKey,
+            // TODO: will apply error handling when reworking the Rust API
+            _ => unreachable!("missing or invalid key namespace: {value}"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[repr(C, u8)]
 pub enum KeyMetadata {
     #[default]
     None,
     Basic {
-        namespace: u8,
+        namespace: KeyNamespace,
     },
 }
 
@@ -198,6 +223,16 @@ impl KeyCode {
     pub fn with_metadata(mut self, meta: KeyMetadata) -> Self {
         self.metadata = meta;
         self
+    }
+
+    pub fn is_advanced_key(&self) -> bool {
+        matches!(
+            self.metadata,
+            KeyMetadata::Basic {
+                namespace: KeyNamespace::AdvancedKey,
+                ..
+            }
+        )
     }
 }
 
@@ -255,19 +290,19 @@ pub enum ValueMetadata {
     #[default]
     None,
     Basic {
-        pos: Position,
+        pos: KeyPosition,
         actuated: bool,
     },
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[repr(C)]
-pub struct Position {
+pub struct KeyPosition {
     x: u8,
     y: u8,
 }
 
-impl Position {
+impl KeyPosition {
     pub fn new(x: u8, y: u8) -> Self {
         Self { x, y }
     }
@@ -398,9 +433,6 @@ pub enum WootingAnalogResult {
     /// Indicates that the Analog SDK could not be found on the system
     #[error("The Wooting Analog SDK could not be found on the system")]
     DLLNotFound = -1990isize,
-    /// Device does not have the required analog protocol
-    #[error("The device does not have the required analog protocol")]
-    IncompatibleAnalogProtocol = -1989isize,
 }
 
 impl WootingAnalogResult {

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -376,6 +376,100 @@ impl From<f32> for AnalogValue {
     }
 }
 
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[repr(C, u8)]
+pub enum V2Data {
+    V1 { keycode: u16, value: f32 },
+    V2(PhysicalKey),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AnalogData {
+    v1: HashMap<u16, f32>,
+    v2: HashMap<KeyPosition, PhysicalKey>,
+}
+
+impl AnalogData {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(v1_capacity: usize, v2_capacity: usize) -> Self {
+        Self {
+            v1: HashMap::with_capacity(v1_capacity),
+            v2: HashMap::with_capacity(v2_capacity),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.v1.is_empty() && self.v2.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.v1.len() + self.v2.len()
+    }
+
+    pub fn insert_v1(&mut self, keycode: u16, value: f32) {
+        self.v1
+            .entry(keycode)
+            .and_modify(|existing| *existing = existing.max(value))
+            .or_insert(value);
+    }
+
+    pub fn insert_v2(&mut self, pk: PhysicalKey) {
+        self.v2
+            .entry(pk.pos)
+            .and_modify(|existing| {
+                if pk.max_value() > existing.max_value() {
+                    *existing = pk;
+                }
+            })
+            .or_insert(pk);
+    }
+
+    pub(crate) fn push_v2_state(&mut self, pos: KeyPosition, state: KeyState) {
+        self.v2
+            .entry(pos)
+            .and_modify(|existing| {
+                existing.push_state(state);
+            })
+            .or_insert_with(|| {
+                let mut pk = PhysicalKey::new(pos);
+                pk.push_state(state);
+                pk
+            });
+    }
+
+    pub fn merge(&mut self, other: AnalogData) {
+        for (keycode, value) in other.v1 {
+            self.insert_v1(keycode, value);
+        }
+        for (_, pk) in other.v2 {
+            self.insert_v2(pk);
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = V2Data> + '_ {
+        self.v1
+            .iter()
+            .map(|(&keycode, &value)| V2Data::V1 { keycode, value })
+            .chain(self.v2.values().cloned().map(V2Data::V2))
+    }
+
+    // TODO: for performance return iterator instead since FFI will iterate over these anyway to
+    // copy them into the raw V2Data pointer. could make this function pub(crate) so only our FFI
+    // functions can use it, feels like it wouldn't be useful for rust side anyway.
+    pub fn into_vec(self) -> Vec<V2Data> {
+        self.v1
+            .into_iter()
+            .map(|(keycode, value)| V2Data::V1 { keycode, value })
+            .chain(self.v2.into_values().map(V2Data::V2))
+            .collect()
+    }
+}
+
 // should not be publicly accessible
 #[derive(Clone, PartialEq, PartialOrd, Debug, Default)]
 #[repr(C)]

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -59,7 +59,6 @@ pub trait Plugin {
     /// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
     fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32>;
 
-    // TODO: return type - might want a AnalogV2Value or something and convert AnalogValue to that.
     fn read_analog_with_ctx(
         &mut self,
         key_source: KeySource,
@@ -74,17 +73,13 @@ pub trait Plugin {
         max_length: usize,
         device: DeviceID,
     ) -> SDKResult<HashMap<c_ushort, c_float>>;
-}
 
-// // TODO: prototype
-// #[derive(Debug)]
-// #[repr(C)]
-// pub struct AnalogV2Value {
-//     pub actuated: bool,
-//     pub position: Position,
-//     pub value: f32,
-//     // TODO: akc_active: bool
-// }
+    fn read_full_buffer_with_ctx(
+        &mut self,
+        max_length: usize,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyCode, AnalogValue>>;
+}
 
 const ANALOG_BUFFER_SIZE_V1: usize = 48;
 const ANALOG_BUFFER_SIZE_V2: usize = 64;
@@ -448,7 +443,7 @@ impl Device {
 
     fn read_analog_with_ctx(&mut self, key_source: KeySource) -> SDKResult<AnalogValue> {
         let value = match key_source {
-            KeySource::Code(code) => *self
+            KeySource::Raw(code) => *self
                 .buffer
                 .lock()
                 .unwrap()
@@ -718,7 +713,7 @@ impl Plugin for WootingPlugin {
     }
 
     fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32> {
-        let value = self.read_analog_with_ctx(KeySource::Code(code), device_id);
+        let value = self.read_analog_with_ctx(KeySource::Raw(code), device_id);
 
         match value.0 {
             Ok(v) => v.inner.into(),
@@ -834,6 +829,75 @@ impl Plugin for WootingPlugin {
                     Ok(val) => {
                         Ok(val.iter().map(|(k, v)| (k.as_u16(), v.as_f32())).collect()).into()
                     }
+                    Err(e) => Err(e).into(),
+                },
+                None => Err(WootingAnalogResult::NoDevices).into(),
+            }
+        }
+    }
+
+    fn read_full_buffer_with_ctx(
+        &mut self,
+        max_length: usize,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+        if !self.initialised.load(Ordering::Relaxed) {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        if self.devices.lock().unwrap().is_empty() {
+            return Err(WootingAnalogResult::NoDevices).into();
+        }
+
+        //If the Device ID is 0 we want to go through all the connected devices
+        //and combine the analog values
+        if device_id == 0 {
+            let mut analog = HashMap::new();
+            let mut any_read = false;
+            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+            for (_id, device) in self.devices.lock().unwrap().iter_mut() {
+                match device.read_full_with_ctx().into() {
+                    Ok(val) => {
+                        for (k, v) in val {
+                            analog
+                                .entry(k)
+                                .and_modify(|value| {
+                                    if &v > value {
+                                        *value = v;
+                                    }
+                                })
+                                .or_insert(v);
+                            any_read = true;
+                        }
+                    }
+                    Err(e) => {
+                        error = e;
+                    }
+                }
+            }
+
+            if !any_read {
+                Err(error).into()
+            } else {
+                // TODO: convert virtual keyboard to use KeyCode and AnalogValue
+                // #[cfg(feature = "virtual-input")]
+                // self.virtual_keyboard.iter_over(|iter| {
+                //     for (key, value) in iter {
+                //         analog
+                //             .entry(*key)
+                //             .and_modify(|v| *v = v.max(*value))
+                //             .or_insert(*value);
+                //     }
+                // });
+
+                Ok(analog).into()
+            }
+        } else
+        //If the device id is not 0, we try and find a connected device with that ID and read from it
+        {
+            match self.devices.lock().unwrap().get_mut(&device_id) {
+                Some(device) => match device.read_full_with_ctx().into() {
+                    Ok(val) => Ok(val).into(),
                     Err(e) => Err(e).into(),
                 },
                 None => Err(WootingAnalogResult::NoDevices).into(),

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -16,8 +16,8 @@ use std::{str, thread};
 #[cfg(feature = "virtual-input")]
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, KeyCode, KeyMetadata, Position,
-    SDKResult, ValueMetadata, WootingAnalogResult,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, KeyCode, KeyMetadata,
+    KeySource, Position, SDKResult, ValueMetadata, WootingAnalogResult,
 };
 
 #[cfg(target_os = "macos")]
@@ -57,7 +57,14 @@ pub trait Plugin {
 
     /// Function called to get the analog value for a particular HID key `code` from the device with ID `device`.
     /// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
-    fn read_analog(&mut self, code: u16, device: DeviceID) -> SDKResult<f32>;
+    fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32>;
+
+    // TODO: return type - might want a AnalogV2Value or something and convert AnalogValue to that.
+    fn read_analog_with_ctx(
+        &mut self,
+        key_source: KeySource,
+        device: DeviceID,
+    ) -> SDKResult<AnalogValue>;
 
     /// Function called to get the full analog read buffer for a particular device with ID `device`. `max_length` is the maximum amount
     /// of keys that can be accepted, any more beyond this will be ignored by the SDK.
@@ -68,6 +75,16 @@ pub trait Plugin {
         device: DeviceID,
     ) -> SDKResult<HashMap<c_ushort, c_float>>;
 }
+
+// // TODO: prototype
+// #[derive(Debug)]
+// #[repr(C)]
+// pub struct AnalogV2Value {
+//     pub actuated: bool,
+//     pub position: Position,
+//     pub value: f32,
+//     // TODO: akc_active: bool
+// }
 
 const ANALOG_BUFFER_SIZE_V1: usize = 48;
 const ANALOG_BUFFER_SIZE_V2: usize = 64;
@@ -429,13 +446,34 @@ impl Device {
         )
     }
 
-    fn read_analog_with_ctx(&mut self, code: KeyCode) -> SDKResult<AnalogValue> {
-        SDKResult(Ok(*self
-            .buffer
-            .lock()
-            .unwrap()
-            .get(&code)
-            .unwrap_or(&AnalogValue::default())))
+    fn read_analog_with_ctx(&mut self, key_source: KeySource) -> SDKResult<AnalogValue> {
+        let value = match key_source {
+            KeySource::Code(code) => *self
+                .buffer
+                .lock()
+                .unwrap()
+                // TODO: could add this directly to KeySource?
+                .get(&KeyCode::from(code))
+                .unwrap_or(&AnalogValue::default()),
+            KeySource::Position(position) => self
+                .buffer
+                .lock()
+                .unwrap()
+                .iter()
+                .find_map(|(_, v)| match v.metadata {
+                    ValueMetadata::None => None,
+                    ValueMetadata::Basic { pos, .. } => {
+                        if pos == position {
+                            Some(*v)
+                        } else {
+                            None
+                        }
+                    }
+                })
+                .unwrap_or(AnalogValue::default()),
+        };
+
+        SDKResult(Ok(value))
     }
 
     fn read_full_with_ctx(&mut self) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
@@ -680,6 +718,19 @@ impl Plugin for WootingPlugin {
     }
 
     fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32> {
+        let value = self.read_analog_with_ctx(KeySource::Code(code), device_id);
+
+        match value.0 {
+            Ok(v) => v.inner.into(),
+            Err(e) => Err(e).into(),
+        }
+    }
+
+    fn read_analog_with_ctx(
+        &mut self,
+        key_source: KeySource,
+        device_id: DeviceID,
+    ) -> SDKResult<AnalogValue> {
         if !self.initialised.load(Ordering::Relaxed) {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
@@ -691,30 +742,28 @@ impl Plugin for WootingPlugin {
         //If the Device ID is 0 we want to go through all the connected devices
         //and combine the analog values
         if device_id == 0 {
-            let mut analog: f32 = -1.0;
+            let mut analog: AnalogValue = AnalogValue::from(-1.0);
             let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_analog_with_ctx(code.into()).into() {
-                    Ok(val) => {
-                        analog = analog.max(val.as_f32());
-                    }
-                    Err(e) => {
-                        error = e;
-                    }
+                match device.read_analog_with_ctx(key_source).into() {
+                    Ok(val) => analog = analog.max(val),
+                    Err(e) => error = e,
                 }
             }
 
-            if analog < 0.0 {
+            if analog < 0.0
+            /*|| analog.metadata == ValueMetadata::None*/
+            {
                 Err(error).into()
             } else {
-                analog.into()
+                SDKResult(Ok(analog))
             }
         } else
         //If the device id is not 0, we try and find a connected device with that ID and read from it
         {
             match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => match device.read_analog_with_ctx(code.into()).into() {
-                    Ok(val) => val.as_f32().into(),
+                Some(device) => match device.read_analog_with_ctx(key_source).into() {
+                    Ok(val) => Ok(val).into(),
                     Err(e) => Err(e).into(),
                 },
                 None => Err(WootingAnalogResult::NoDevices).into(),

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -16,7 +16,7 @@ use std::{str, thread};
 #[cfg(feature = "virtual-input")]
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, KeyCode, KeyMetadata, KeyNamespace, KeySource, KeyPosition, SDKResult, ValueMetadata, WootingAnalogResult
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, Key, KeyCode, KeyMetadata, KeyNamespace, KeyPosition, KeySource, KeyState, PhysicalKey, SDKResult, ValueMetadata, WootingAnalogResult
 };
 
 #[cfg(target_os = "macos")]
@@ -77,7 +77,7 @@ pub trait Plugin {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyCode, AnalogValue>>;
+    ) -> SDKResult<Vec<PhysicalKey>>;
 }
 
 const ANALOG_BUFFER_SIZE_V1: usize = 48;
@@ -164,7 +164,7 @@ trait DeviceImplementation: DynClone + Send {
         &self,
         _device: &HidDevice,
         _max_length: usize,
-    ) -> SDKResult<Option<HashMap<KeyCode, AnalogValue>>> {
+    ) -> SDKResult<Option<Vec<Key>>> {
         SDKResult(Ok(None))
     }
 
@@ -253,7 +253,7 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                 Ok(data) => match data {
                     Some(data) => Ok(Some(
                         data.iter()
-                            .map(|(k, v)| (k.as_u16(), v.as_f32()))
+                            .map(|k| (k.code.as_u16(), k.value.as_f32()))
                             .collect::<HashMap<c_ushort, c_float>>(),
                     )),
                     None => Ok(None),
@@ -267,7 +267,7 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
         &self,
         device: &HidDevice,
         max_length: usize,
-    ) -> SDKResult<Option<HashMap<KeyCode, AnalogValue>>> {
+    ) -> SDKResult<Option<Vec<Key>>> {
         let mut buffer: [u8; ANALOG_BUFFER_SIZE_V2] = [0; ANALOG_BUFFER_SIZE_V2];
         let res = device.read_timeout(&mut buffer, 50);
 
@@ -304,18 +304,18 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
 
                     let value = (u16::from(value) << 2) | u16::from(value_part);
 
-                    (
-                        KeyCode::from((u16::from(key_namespace) << 8) | u16::from(key))
+                    Key {
+                        code: KeyCode::from((u16::from(key_namespace) << 8) | u16::from(key))
                             .with_metadata(KeyMetadata::Basic {
                                 namespace: KeyNamespace::from(key_namespace),
                             }),
-                        AnalogValue::from(self.analog_value_to_float(value)).with_metadata(
+                        value: AnalogValue::from(self.analog_value_to_float(value)).with_metadata(
                             ValueMetadata::Basic {
                                 pos: KeyPosition::new(col, row),
                                 actuated,
                             },
                         ),
-                    )
+                    }
                 })
                 .collect(),
         ))
@@ -330,9 +330,9 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
 /// A fully contained device which uses `device_impl` to interface with the `device`
 struct Device {
     pub device_info: DeviceInfo,
-    buffer: Arc<Mutex<HashMap<KeyCode, AnalogValue>>>,
+    buffer: Arc<Mutex<Vec<Key>>>,
     connected: Arc<AtomicBool>,
-    pressed_keys: Vec<KeyCode>,
+    pressed_keys: Vec<Key>,
     worker: Option<JoinHandle<i32>>,
 }
 unsafe impl Send for Device {}
@@ -345,7 +345,7 @@ impl Device {
     ) -> (DeviceID, Self) {
         let id_hash = device_impl.get_device_id(device_info);
 
-        let buffer: Arc<Mutex<HashMap<KeyCode, AnalogValue>>> = Default::default();
+        let buffer: Arc<Mutex<Vec<Key>>> = Default::default();
         let connected = Arc::new(AtomicBool::new(true));
 
         let worker = {
@@ -368,9 +368,9 @@ impl Device {
                                     if let Some(data) = data {
                                         let mut map = t_buffer.lock().unwrap();
                                         map.clear();
-                                        map.extend(data.iter().map(|(k, v)| {
-                                            (KeyCode::from(*k), AnalogValue::from(*v))
-                                        }));
+                                        map.extend(data.iter().map(|(k, v)| 
+                                            Key { code: KeyCode::from(*k), value: AnalogValue::from(*v) }
+                                        ));
                                     }
                                 }
                                 Err(e) => {
@@ -440,14 +440,14 @@ impl Device {
         )
     }
 
-    fn read_analog_with_ctx(&mut self, key_source: KeySource) -> SDKResult<AnalogValue> {
+    fn read_analog_with_ctx(&mut self, key_source: KeySource) -> SDKResult<Key> {
         let buffer_guard = self.buffer.lock().unwrap();
 
-        let value = match key_source {
-            KeySource::Raw(code) => buffer_guard.get(&KeyCode::from(code)).copied(),
-            KeySource::Code(code) => buffer_guard.get(&code).copied(),
-            KeySource::Position(position) => buffer_guard.values().find_map(|v| match v.metadata {
-                ValueMetadata::Basic { pos, .. } if pos == position => Some(*v),
+        let value: Option<Key> = match key_source {
+            KeySource::Raw(code) => buffer_guard.iter().find(|k| k.code.as_u16() == code).cloned(),
+            KeySource::Code(code) => buffer_guard.iter().find(|k| k.code == code).cloned(),
+            KeySource::Position(position) => buffer_guard.iter().find_map(|k| match k.value.metadata {
+                ValueMetadata::Basic { pos, .. } if pos == position => Some(k.clone()),
                 _ => None,
             }),
         };
@@ -455,17 +455,22 @@ impl Device {
         SDKResult(Ok(value.unwrap_or_default()))
     }
 
-    fn read_full_with_ctx(&mut self) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+    fn read_full_with_ctx(&mut self) -> SDKResult<Vec<Key>> {
         let mut buffer = self.buffer.lock().unwrap().clone();
-        //Collect the new pressed keys
-        let new_pressed_keys: Vec<KeyCode> = buffer.keys().cloned().collect();
+        let new_pressed_keys = buffer.clone();
 
-        //Put the old pressed keys into the buffer
+        // Build set of current keycodes for O(1) lookup
+        let current_codes: std::collections::HashSet<KeyCode> =
+            buffer.iter().map(|k| k.code).collect();
+
+        // Add old pressed keys that are no longer pressed (for key release detection)
         for key in self.pressed_keys.drain(..) {
-            buffer.entry(key).or_default();
+            if !current_codes.contains(&key.code) {
+                buffer.push(key)
+            }
         }
 
-        //Store the newPressedKeys for the next call
+        // Store only the currently pressed keys for the next call
         self.pressed_keys = new_pressed_keys;
 
         Ok(buffer).into()
@@ -725,7 +730,7 @@ impl Plugin for WootingPlugin {
             let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
                 match device.read_analog_with_ctx(key_source).into() {
-                    Ok(val) => analog = analog.max(val),
+                    Ok(key) => analog = analog.max(key.value),
                     Err(e) => error = e,
                 }
             }
@@ -742,7 +747,7 @@ impl Plugin for WootingPlugin {
         {
             match self.devices.lock().unwrap().get_mut(&device_id) {
                 Some(device) => match device.read_analog_with_ctx(key_source).into() {
-                    Ok(val) => Ok(val).into(),
+                    Ok(key) => Ok(key.value).into(),
                     Err(e) => Err(e).into(),
                 },
                 None => Err(WootingAnalogResult::NoDevices).into(),
@@ -772,7 +777,7 @@ impl Plugin for WootingPlugin {
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
                 match device.read_full_with_ctx().into() {
                     Ok(val) => {
-                        for (k, v) in val.iter().map(|(k, v)| (k.as_u16(), v.as_f32())) {
+                        for (k, v) in val.iter().map(|k| (k.code.as_u16(), k.value.as_f32())) {
                             analog
                                 .entry(k)
                                 .and_modify(|value| {
@@ -781,8 +786,9 @@ impl Plugin for WootingPlugin {
                                     }
                                 })
                                 .or_insert(v);
-                            any_read = true;
                         }
+                            any_read = true;
+
                     }
                     Err(e) => {
                         error = e;
@@ -811,7 +817,7 @@ impl Plugin for WootingPlugin {
             match self.devices.lock().unwrap().get_mut(&device_id) {
                 Some(device) => match device.read_full_with_ctx().into() {
                     Ok(val) => {
-                        Ok(val.iter().map(|(k, v)| (k.as_u16(), v.as_f32())).collect()).into()
+                        Ok(val.iter().map(|k| (k.code.as_u16(), k.value.as_f32())).collect()).into()
                     }
                     Err(e) => Err(e).into(),
                 },
@@ -824,7 +830,7 @@ impl Plugin for WootingPlugin {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+    ) -> SDKResult<Vec<PhysicalKey>> {
         if !self.initialised.load(Ordering::Relaxed) {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
@@ -836,28 +842,52 @@ impl Plugin for WootingPlugin {
         //If the Device ID is 0 we want to go through all the connected devices
         //and combine the analog values
         if device_id == 0 {
-            let mut analog = HashMap::new();
+            let mut map: HashMap<KeyPosition, PhysicalKey> = HashMap::new();
             let mut any_read = false;
             let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
                 match device.read_full_with_ctx().into() {
-                    Ok(val) => {
-                        for (k, v) in val {
-                            analog
-                                .entry(k)
-                                .and_modify(|value| {
-                                    if &v > value {
-                                        *value = v;
-                                    }
-                                })
-                                .or_insert(v);
-                            any_read = true;
-                        }
-                    }
-                    Err(e) => {
-                        error = e;
+              Ok(keys) => {
+                  // First, group this device's keys by position
+                  let mut device_map: HashMap<KeyPosition, PhysicalKey> = HashMap::new();
+
+                  for key in keys {
+                    if let ValueMetadata::Basic { pos, actuated } = key.value.metadata {
+                        let key_state = KeyState {
+                            value: key.value.inner,
+                            keycode: key.code,
+                            actuated,
+                        };
+
+                        device_map.entry(pos)
+                            .and_modify(|pk| { pk.push_state(key_state); })
+                            .or_insert_with(|| {
+                                let mut pk = PhysicalKey::new(pos);
+                                pk.push_state(key_state);
+                                pk
+                            });
                     }
                 }
+
+                // Merge into main map, keeping highest value per position
+                for (pos, device_pk) in device_map {
+                    let device_max = device_pk.max_value();
+
+                    map.entry(pos)
+                        .and_modify(|existing_pk| {
+                            if device_max > existing_pk.max_value() {
+                                *existing_pk = device_pk;
+                            }
+                        })
+                        .or_insert(device_pk);
+                }
+
+                  any_read = true;
+              }
+              Err(e) => {
+                  error = e;
+              }
+          }
             }
 
             if !any_read {
@@ -874,14 +904,38 @@ impl Plugin for WootingPlugin {
                 //     }
                 // });
 
-                Ok(analog).into()
+                let physical_keys: Vec<PhysicalKey> = map.into_values().collect();
+                Ok(physical_keys).into()
             }
         } else
         //If the device id is not 0, we try and find a connected device with that ID and read from it
         {
             match self.devices.lock().unwrap().get_mut(&device_id) {
                 Some(device) => match device.read_full_with_ctx().into() {
-                    Ok(val) => Ok(val).into(),
+                    Ok(keys) => {
+                        let mut map: HashMap<KeyPosition, PhysicalKey> = HashMap::new();
+
+                        for key in keys {
+                            if let ValueMetadata::Basic { pos, actuated } = key.value.metadata {
+                                let key_state = KeyState {
+                                    value: key.value.inner,
+                                    keycode: key.code,
+                                    actuated,
+                                };
+
+                                map.entry(pos)
+                                    .and_modify(|pk| { pk.push_state(key_state); })
+                                    .or_insert_with(|| {
+                                        let mut pk = PhysicalKey::new(pos);
+                                        pk.push_state(key_state);
+                                        pk
+                                    });
+                            }
+                        }
+
+                        let physical_keys: Vec<PhysicalKey> = map.into_values().collect();
+                        Ok(physical_keys).into()
+                    },
                     Err(e) => Err(e).into(),
                 },
                 None => Err(WootingAnalogResult::NoDevices).into(),

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -17,8 +17,8 @@ use std::{str, thread};
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
     AnalogData, AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, Key, KeyCode,
-    KeyMetadata, KeyNamespace, KeyPosition, KeySource, KeyState, PhysicalKey, SDKResult,
-    ValueMetadata, WootingAnalogResult,
+    KeyMetadata, KeyNamespace, KeyPosition, KeyState, PhysicalKey, SDKResult, ValueMetadata,
+    WootingAnalogResult,
 };
 
 #[cfg(target_os = "macos")]
@@ -60,11 +60,13 @@ pub trait Plugin {
     /// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
     fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32>;
 
-    fn read_analog_with_ctx(
+    fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue>;
+
+    fn read_position(
         &mut self,
-        key_source: KeySource,
-        device: DeviceID,
-    ) -> SDKResult<AnalogValue>;
+        position: KeyPosition,
+        device_id: DeviceID,
+    ) -> SDKResult<PhysicalKey>;
 
     /// Function called to get the full analog read buffer for a particular device with ID `device`. `max_length` is the maximum amount
     /// of keys that can be accepted, any more beyond this will be ignored by the SDK.
@@ -75,11 +77,19 @@ pub trait Plugin {
         device: DeviceID,
     ) -> SDKResult<HashMap<c_ushort, c_float>>;
 
-    fn read_full_buffer_with_ctx(
+    fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData>;
+
+    fn read_keycodes(
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<AnalogData>;
+    ) -> SDKResult<HashMap<KeyCode, AnalogValue>>;
+
+    fn read_positions(
+        &mut self,
+        max_length: usize,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyPosition, PhysicalKey>>;
 }
 
 const ANALOG_BUFFER_SIZE_V1: usize = 48;
@@ -443,24 +453,36 @@ impl Device {
         )
     }
 
-    fn read_analog_with_ctx(&mut self, key_source: KeySource) -> SDKResult<Key> {
+    fn read_keycode(&mut self, code: KeyCode) -> SDKResult<AnalogValue> {
         let buffer_guard = self.buffer.lock().unwrap();
 
-        let value: Option<Key> = match key_source {
-            KeySource::Raw(code) => buffer_guard
-                .iter()
-                .find(|k| k.code.as_u16() == code)
-                .cloned(),
-            KeySource::Code(code) => buffer_guard.iter().find(|k| k.code == code).cloned(),
-            KeySource::Position(position) => {
-                buffer_guard.iter().find_map(|k| match k.value.metadata {
-                    ValueMetadata::Basic { pos, .. } if pos == position => Some(k.clone()),
-                    _ => None,
-                })
-            }
-        };
+        let value = buffer_guard
+            .iter()
+            .find(|k| k.code == code)
+            .map(|k| k.value)
+            .unwrap_or_default();
 
-        SDKResult(Ok(value.unwrap_or_default()))
+        SDKResult(Ok(value))
+    }
+
+    fn read_position(&mut self, position: KeyPosition) -> SDKResult<PhysicalKey> {
+        let buffer_guard = self.buffer.lock().unwrap();
+
+        let mut physical_key = PhysicalKey::new(position);
+
+        for key in buffer_guard.iter() {
+            if let ValueMetadata::Basic { pos, actuated } = key.value.metadata {
+                if pos == position {
+                    physical_key.push_state(KeyState {
+                        value: key.value.inner,
+                        keycode: key.code,
+                        actuated,
+                    });
+                }
+            }
+        }
+
+        SDKResult(Ok(physical_key))
     }
 
     fn read_full_with_ctx(&mut self) -> SDKResult<Vec<Key>> {
@@ -710,19 +732,13 @@ impl Plugin for WootingPlugin {
     }
 
     fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32> {
-        let value = self.read_analog_with_ctx(KeySource::Raw(code), device_id);
-
-        match value.0 {
+        match self.read_keycode(KeyCode::from(code), device_id).0 {
             Ok(v) => v.inner.into(),
             Err(e) => Err(e).into(),
         }
     }
 
-    fn read_analog_with_ctx(
-        &mut self,
-        key_source: KeySource,
-        device_id: DeviceID,
-    ) -> SDKResult<AnalogValue> {
+    fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue> {
         if !self.initialised.load(Ordering::Relaxed) {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
@@ -731,33 +747,66 @@ impl Plugin for WootingPlugin {
             return Err(WootingAnalogResult::NoDevices).into();
         }
 
-        //If the Device ID is 0 we want to go through all the connected devices
-        //and combine the analog values
         if device_id == 0 {
-            let mut analog: AnalogValue = AnalogValue::from(-1.0);
-            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+            let mut analog = AnalogValue::from(-1.0);
+            let mut error = WootingAnalogResult::Ok;
+
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_analog_with_ctx(key_source).into() {
-                    Ok(key) => analog = analog.max(key.value),
+                match device.read_keycode(code).into() {
+                    Ok(value) => analog = analog.max(value),
                     Err(e) => error = e,
                 }
             }
 
-            if analog < 0.0
-            /*|| analog.metadata == ValueMetadata::None*/
-            {
+            if analog < 0.0 {
                 Err(error).into()
             } else {
                 SDKResult(Ok(analog))
             }
-        } else
-        //If the device id is not 0, we try and find a connected device with that ID and read from it
-        {
+        } else {
             match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => match device.read_analog_with_ctx(key_source).into() {
-                    Ok(key) => Ok(key.value).into(),
-                    Err(e) => Err(e).into(),
-                },
+                Some(device) => device.read_keycode(code),
+                None => Err(WootingAnalogResult::NoDevices).into(),
+            }
+        }
+    }
+
+    fn read_position(
+        &mut self,
+        position: KeyPosition,
+        device_id: DeviceID,
+    ) -> SDKResult<PhysicalKey> {
+        if !self.initialised.load(Ordering::Relaxed) {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        if self.devices.lock().unwrap().is_empty() {
+            return Err(WootingAnalogResult::NoDevices).into();
+        }
+
+        if device_id == 0 {
+            let mut result = PhysicalKey::new(position);
+            let mut error = WootingAnalogResult::Ok;
+
+            for (_id, device) in self.devices.lock().unwrap().iter_mut() {
+                match device.read_position(position).into() {
+                    Ok(pk) => {
+                        for i in 0..pk.state_count {
+                            result.push_state(pk.states[i as usize]);
+                        }
+                    }
+                    Err(e) => error = e,
+                }
+            }
+
+            if result.state_count == 0 {
+                Err(error).into()
+            } else {
+                SDKResult(Ok(result))
+            }
+        } else {
+            match self.devices.lock().unwrap().get_mut(&device_id) {
+                Some(device) => device.read_position(position),
                 None => Err(WootingAnalogResult::NoDevices).into(),
             }
         }
@@ -835,37 +884,13 @@ impl Plugin for WootingPlugin {
         }
     }
 
-    fn read_full_buffer_with_ctx(
-        &mut self,
-        _max_length: usize,
-        device_id: DeviceID,
-    ) -> SDKResult<AnalogData> {
+    fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData> {
         if !self.initialised.load(Ordering::Relaxed) {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
 
         if self.devices.lock().unwrap().is_empty() {
             return Err(WootingAnalogResult::NoDevices).into();
-        }
-
-        // TODO: needs to be taken out later, will tidy this up when working on the new rust api
-        fn keys_to_analog_data(keys: Vec<Key>, data: &mut AnalogData) {
-            for key in keys {
-                match key.value.metadata {
-                    ValueMetadata::None => {
-                        data.insert_v1(key.code.as_u16(), key.value.as_f32());
-                    }
-                    ValueMetadata::Basic { pos, actuated } => {
-                        let key_state = KeyState {
-                            value: key.value.inner,
-                            keycode: key.code,
-                            actuated,
-                        };
-                        // Accumulate states at the same position
-                        data.push_v2_state(pos, key_state);
-                    }
-                }
-            }
         }
 
         // If the Device ID is 0 we want to go through all the connected devices
@@ -878,8 +903,7 @@ impl Plugin for WootingPlugin {
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
                 match device.read_full_with_ctx().into() {
                     Ok(keys) => {
-                        let mut device_data = AnalogData::new();
-                        keys_to_analog_data(keys, &mut device_data);
+                        let device_data = AnalogData::from(keys);
                         combined.merge(device_data);
                         any_read = true;
                     }
@@ -909,11 +933,129 @@ impl Plugin for WootingPlugin {
             // If the device id is not 0, we try and find a connected device with that ID and read from it
             match self.devices.lock().unwrap().get_mut(&device_id) {
                 Some(device) => match device.read_full_with_ctx().into() {
+                    Ok(keys) => Ok(AnalogData::from(keys)).into(),
+                    Err(e) => Err(e).into(),
+                },
+                None => Err(WootingAnalogResult::NoDevices).into(),
+            }
+        }
+    }
+
+    fn read_keycodes(
+        &mut self,
+        max_length: usize,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+        if !self.initialised.load(Ordering::Relaxed) {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        if self.devices.lock().unwrap().is_empty() {
+            return Err(WootingAnalogResult::NoDevices).into();
+        }
+
+        // If the Device ID is 0 we want to go through all the connected devices
+        // and combine the analog values
+        if device_id == 0 {
+            let mut combined = AnalogData::new();
+            let mut any_read = false;
+            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+
+            for (_id, device) in self.devices.lock().unwrap().iter_mut() {
+                match device.read_full_with_ctx().into() {
                     Ok(keys) => {
-                        let mut data = AnalogData::new();
-                        keys_to_analog_data(keys, &mut data);
-                        Ok(data).into()
+                        let device_data = AnalogData::from(keys);
+                        combined.merge(device_data);
+                        any_read = true;
                     }
+                    Err(e) => {
+                        error = e;
+                    }
+                }
+            }
+
+            if !any_read {
+                Err(error).into()
+            } else {
+                // TODO: convert virtual keyboard to use KeyCode and AnalogValue
+                // #[cfg(feature = "virtual-input")]
+                // self.virtual_keyboard.iter_over(|iter| {
+                //     for (key, value) in iter {
+                //         analog
+                //             .entry(*key)
+                //             .and_modify(|v| *v = v.max(*value))
+                //             .or_insert(*value);
+                //     }
+                // });
+
+                Ok(combined.keycode_based).into()
+            }
+        } else {
+            // If the device id is not 0, we try and find a connected device with that ID and read from it
+            match self.devices.lock().unwrap().get_mut(&device_id) {
+                Some(device) => match device.read_full_with_ctx().into() {
+                    Ok(keys) => Ok(AnalogData::from(keys).keycode_based).into(),
+                    Err(e) => Err(e).into(),
+                },
+                None => Err(WootingAnalogResult::NoDevices).into(),
+            }
+        }
+    }
+
+    fn read_positions(
+        &mut self,
+        max_length: usize,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyPosition, PhysicalKey>> {
+        if !self.initialised.load(Ordering::Relaxed) {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        if self.devices.lock().unwrap().is_empty() {
+            return Err(WootingAnalogResult::NoDevices).into();
+        }
+
+        // If the Device ID is 0 we want to go through all the connected devices
+        // and combine the analog values
+        if device_id == 0 {
+            let mut combined = AnalogData::new();
+            let mut any_read = false;
+            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+
+            for (_id, device) in self.devices.lock().unwrap().iter_mut() {
+                match device.read_full_with_ctx().into() {
+                    Ok(keys) => {
+                        let device_data = AnalogData::from(keys);
+                        combined.merge(device_data);
+                        any_read = true;
+                    }
+                    Err(e) => {
+                        error = e;
+                    }
+                }
+            }
+
+            if !any_read {
+                Err(error).into()
+            } else {
+                // TODO: convert virtual keyboard to use KeyCode and AnalogValue
+                // #[cfg(feature = "virtual-input")]
+                // self.virtual_keyboard.iter_over(|iter| {
+                //     for (key, value) in iter {
+                //         analog
+                //             .entry(*key)
+                //             .and_modify(|v| *v = v.max(*value))
+                //             .or_insert(*value);
+                //     }
+                // });
+
+                Ok(combined.position_based).into()
+            }
+        } else {
+            // If the device id is not 0, we try and find a connected device with that ID and read from it
+            match self.devices.lock().unwrap().get_mut(&device_id) {
+                Some(device) => match device.read_full_with_ctx().into() {
+                    Ok(keys) => Ok(AnalogData::from(keys).position_based).into(),
                     Err(e) => Err(e).into(),
                 },
                 None => Err(WootingAnalogResult::NoDevices).into(),

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -16,8 +16,7 @@ use std::{str, thread};
 #[cfg(feature = "virtual-input")]
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, KeyCode, KeyMetadata,
-    KeySource, Position, SDKResult, ValueMetadata, WootingAnalogResult,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, KeyCode, KeyMetadata, KeyNamespace, KeySource, KeyPosition, SDKResult, ValueMetadata, WootingAnalogResult
 };
 
 #[cfg(target_os = "macos")]
@@ -308,11 +307,11 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                     (
                         KeyCode::from((u16::from(key_namespace) << 8) | u16::from(key))
                             .with_metadata(KeyMetadata::Basic {
-                                namespace: key_namespace,
+                                namespace: KeyNamespace::from(key_namespace),
                             }),
                         AnalogValue::from(self.analog_value_to_float(value)).with_metadata(
                             ValueMetadata::Basic {
-                                pos: Position::new(col, row),
+                                pos: KeyPosition::new(col, row),
                                 actuated,
                             },
                         ),
@@ -442,33 +441,18 @@ impl Device {
     }
 
     fn read_analog_with_ctx(&mut self, key_source: KeySource) -> SDKResult<AnalogValue> {
+        let buffer_guard = self.buffer.lock().unwrap();
+
         let value = match key_source {
-            KeySource::Raw(code) => *self
-                .buffer
-                .lock()
-                .unwrap()
-                // TODO: could add this directly to KeySource?
-                .get(&KeyCode::from(code))
-                .unwrap_or(&AnalogValue::default()),
-            KeySource::Position(position) => self
-                .buffer
-                .lock()
-                .unwrap()
-                .iter()
-                .find_map(|(_, v)| match v.metadata {
-                    ValueMetadata::None => None,
-                    ValueMetadata::Basic { pos, .. } => {
-                        if pos == position {
-                            Some(*v)
-                        } else {
-                            None
-                        }
-                    }
-                })
-                .unwrap_or(AnalogValue::default()),
+            KeySource::Raw(code) => buffer_guard.get(&KeyCode::from(code)).copied(),
+            KeySource::Code(code) => buffer_guard.get(&code).copied(),
+            KeySource::Position(position) => buffer_guard.values().find_map(|v| match v.metadata {
+                ValueMetadata::Basic { pos, .. } if pos == position => Some(*v),
+                _ => None,
+            }),
         };
 
-        SDKResult(Ok(value))
+        SDKResult(Ok(value.unwrap_or_default()))
     }
 
     fn read_full_with_ctx(&mut self) -> SDKResult<HashMap<KeyCode, AnalogValue>> {

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -16,7 +16,9 @@ use std::{str, thread};
 #[cfg(feature = "virtual-input")]
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, Key, KeyCode, KeyMetadata, KeyNamespace, KeyPosition, KeySource, KeyState, PhysicalKey, SDKResult, ValueMetadata, WootingAnalogResult
+    AnalogData, AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, Key, KeyCode,
+    KeyMetadata, KeyNamespace, KeyPosition, KeySource, KeyState, PhysicalKey, SDKResult,
+    ValueMetadata, WootingAnalogResult,
 };
 
 #[cfg(target_os = "macos")]
@@ -77,7 +79,7 @@ pub trait Plugin {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<Vec<PhysicalKey>>;
+    ) -> SDKResult<AnalogData>;
 }
 
 const ANALOG_BUFFER_SIZE_V1: usize = 48;
@@ -368,9 +370,10 @@ impl Device {
                                     if let Some(data) = data {
                                         let mut map = t_buffer.lock().unwrap();
                                         map.clear();
-                                        map.extend(data.iter().map(|(k, v)| 
-                                            Key { code: KeyCode::from(*k), value: AnalogValue::from(*v) }
-                                        ));
+                                        map.extend(data.iter().map(|(k, v)| Key {
+                                            code: KeyCode::from(*k),
+                                            value: AnalogValue::from(*v),
+                                        }));
                                     }
                                 }
                                 Err(e) => {
@@ -444,12 +447,17 @@ impl Device {
         let buffer_guard = self.buffer.lock().unwrap();
 
         let value: Option<Key> = match key_source {
-            KeySource::Raw(code) => buffer_guard.iter().find(|k| k.code.as_u16() == code).cloned(),
+            KeySource::Raw(code) => buffer_guard
+                .iter()
+                .find(|k| k.code.as_u16() == code)
+                .cloned(),
             KeySource::Code(code) => buffer_guard.iter().find(|k| k.code == code).cloned(),
-            KeySource::Position(position) => buffer_guard.iter().find_map(|k| match k.value.metadata {
-                ValueMetadata::Basic { pos, .. } if pos == position => Some(k.clone()),
-                _ => None,
-            }),
+            KeySource::Position(position) => {
+                buffer_guard.iter().find_map(|k| match k.value.metadata {
+                    ValueMetadata::Basic { pos, .. } if pos == position => Some(k.clone()),
+                    _ => None,
+                })
+            }
         };
 
         SDKResult(Ok(value.unwrap_or_default()))
@@ -787,8 +795,7 @@ impl Plugin for WootingPlugin {
                                 })
                                 .or_insert(v);
                         }
-                            any_read = true;
-
+                        any_read = true;
                     }
                     Err(e) => {
                         error = e;
@@ -816,9 +823,11 @@ impl Plugin for WootingPlugin {
         {
             match self.devices.lock().unwrap().get_mut(&device_id) {
                 Some(device) => match device.read_full_with_ctx().into() {
-                    Ok(val) => {
-                        Ok(val.iter().map(|k| (k.code.as_u16(), k.value.as_f32())).collect()).into()
-                    }
+                    Ok(val) => Ok(val
+                        .iter()
+                        .map(|k| (k.code.as_u16(), k.value.as_f32()))
+                        .collect())
+                    .into(),
                     Err(e) => Err(e).into(),
                 },
                 None => Err(WootingAnalogResult::NoDevices).into(),
@@ -828,9 +837,9 @@ impl Plugin for WootingPlugin {
 
     fn read_full_buffer_with_ctx(
         &mut self,
-        max_length: usize,
+        _max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<Vec<PhysicalKey>> {
+    ) -> SDKResult<AnalogData> {
         if !self.initialised.load(Ordering::Relaxed) {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
@@ -839,55 +848,45 @@ impl Plugin for WootingPlugin {
             return Err(WootingAnalogResult::NoDevices).into();
         }
 
-        //If the Device ID is 0 we want to go through all the connected devices
-        //and combine the analog values
-        if device_id == 0 {
-            let mut map: HashMap<KeyPosition, PhysicalKey> = HashMap::new();
-            let mut any_read = false;
-            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
-            for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_full_with_ctx().into() {
-              Ok(keys) => {
-                  // First, group this device's keys by position
-                  let mut device_map: HashMap<KeyPosition, PhysicalKey> = HashMap::new();
-
-                  for key in keys {
-                    if let ValueMetadata::Basic { pos, actuated } = key.value.metadata {
+        // TODO: needs to be taken out later, will tidy this up when working on the new rust api
+        fn keys_to_analog_data(keys: Vec<Key>, data: &mut AnalogData) {
+            for key in keys {
+                match key.value.metadata {
+                    ValueMetadata::None => {
+                        data.insert_v1(key.code.as_u16(), key.value.as_f32());
+                    }
+                    ValueMetadata::Basic { pos, actuated } => {
                         let key_state = KeyState {
                             value: key.value.inner,
                             keycode: key.code,
                             actuated,
                         };
-
-                        device_map.entry(pos)
-                            .and_modify(|pk| { pk.push_state(key_state); })
-                            .or_insert_with(|| {
-                                let mut pk = PhysicalKey::new(pos);
-                                pk.push_state(key_state);
-                                pk
-                            });
+                        // Accumulate states at the same position
+                        data.push_v2_state(pos, key_state);
                     }
                 }
+            }
+        }
 
-                // Merge into main map, keeping highest value per position
-                for (pos, device_pk) in device_map {
-                    let device_max = device_pk.max_value();
+        // If the Device ID is 0 we want to go through all the connected devices
+        // and combine the analog values
+        if device_id == 0 {
+            let mut combined = AnalogData::new();
+            let mut any_read = false;
+            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
 
-                    map.entry(pos)
-                        .and_modify(|existing_pk| {
-                            if device_max > existing_pk.max_value() {
-                                *existing_pk = device_pk;
-                            }
-                        })
-                        .or_insert(device_pk);
+            for (_id, device) in self.devices.lock().unwrap().iter_mut() {
+                match device.read_full_with_ctx().into() {
+                    Ok(keys) => {
+                        let mut device_data = AnalogData::new();
+                        keys_to_analog_data(keys, &mut device_data);
+                        combined.merge(device_data);
+                        any_read = true;
+                    }
+                    Err(e) => {
+                        error = e;
+                    }
                 }
-
-                  any_read = true;
-              }
-              Err(e) => {
-                  error = e;
-              }
-          }
             }
 
             if !any_read {
@@ -904,38 +903,17 @@ impl Plugin for WootingPlugin {
                 //     }
                 // });
 
-                let physical_keys: Vec<PhysicalKey> = map.into_values().collect();
-                Ok(physical_keys).into()
+                Ok(combined).into()
             }
-        } else
-        //If the device id is not 0, we try and find a connected device with that ID and read from it
-        {
+        } else {
+            // If the device id is not 0, we try and find a connected device with that ID and read from it
             match self.devices.lock().unwrap().get_mut(&device_id) {
                 Some(device) => match device.read_full_with_ctx().into() {
                     Ok(keys) => {
-                        let mut map: HashMap<KeyPosition, PhysicalKey> = HashMap::new();
-
-                        for key in keys {
-                            if let ValueMetadata::Basic { pos, actuated } = key.value.metadata {
-                                let key_state = KeyState {
-                                    value: key.value.inner,
-                                    keycode: key.code,
-                                    actuated,
-                                };
-
-                                map.entry(pos)
-                                    .and_modify(|pk| { pk.push_state(key_state); })
-                                    .or_insert_with(|| {
-                                        let mut pk = PhysicalKey::new(pos);
-                                        pk.push_state(key_state);
-                                        pk
-                                    });
-                            }
-                        }
-
-                        let physical_keys: Vec<PhysicalKey> = map.into_values().collect();
-                        Ok(physical_keys).into()
-                    },
+                        let mut data = AnalogData::new();
+                        keys_to_analog_data(keys, &mut data);
+                        Ok(data).into()
+                    }
                     Err(e) => Err(e).into(),
                 },
                 None => Err(WootingAnalogResult::NoDevices).into(),

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -163,11 +163,21 @@ impl Plugin for CPlugin {
         self.read_analog(code, device)
     }
 
-    fn read_analog_with_ctx(
+    fn read_keycode(
         &mut self,
-        _key_source: crate::KeySource,
+        _code: crate::KeyCode,
         _device_id: DeviceID,
     ) -> SDKResult<AnalogValue> {
+        // TODO: for now let's assume c plugins can never supply this data
+        // can be possible if we include it as an optional function that they can implement
+        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
+    }
+
+    fn read_position(
+        &mut self,
+        _position: crate::KeyPosition,
+        _device_id: DeviceID,
+    ) -> SDKResult<crate::PhysicalKey> {
         // TODO: for now let's assume c plugins can never supply this data
         // can be possible if we include it as an optional function that they can implement
         SDKResult(Err(WootingAnalogResult::FunctionNotFound))
@@ -207,11 +217,7 @@ impl Plugin for CPlugin {
         Ok(analog_data).into()
     }
 
-    fn read_full_buffer_with_ctx(
-        &mut self,
-        _max_length: usize,
-        _device: DeviceID,
-    ) -> SDKResult<AnalogData> {
+    fn read_full_buffer_with_ctx(&mut self, _device: DeviceID) -> SDKResult<AnalogData> {
         // TODO: for now let's assume c plugins can never supply this data
         // can be possible if we include it as an optional function that they can implement
         SDKResult(Err(WootingAnalogResult::FunctionNotFound))
@@ -251,5 +257,21 @@ impl Plugin for CPlugin {
                 ));
             }
         }
+    }
+
+    fn read_keycodes(
+        &mut self,
+        _max_length: usize,
+        _device_id: DeviceID,
+    ) -> SDKResult<HashMap<crate::KeyCode, AnalogValue>> {
+        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
+    }
+
+    fn read_positions(
+        &mut self,
+        _max_length: usize,
+        _device_id: DeviceID,
+    ) -> SDKResult<HashMap<crate::KeyPosition, crate::PhysicalKey>> {
+        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
     }
 }

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort, c_void};
 
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, Plugin, SDKResult, WootingAnalogResult
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, PhysicalKey, Plugin, SDKResult, WootingAnalogResult
 };
 
 macro_rules! lib_wrap {
@@ -210,7 +210,7 @@ impl Plugin for CPlugin {
         &mut self,
         max_length: usize,
         device: DeviceID,
-    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+    ) -> SDKResult<Vec<PhysicalKey>> {
         // TODO: for now let's assume c plugins can never supply this data
         // can be possible if we include it as an optional function that they can implement
         SDKResult(Err(WootingAnalogResult::FunctionNotFound))

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort, c_void};
 
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, Plugin, SDKResult, WootingAnalogResult
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, Plugin, SDKResult, WootingAnalogResult
 };
 
 macro_rules! lib_wrap {
@@ -204,6 +204,16 @@ impl Plugin for CPlugin {
         }
 
         Ok(analog_data).into()
+    }
+
+    fn read_full_buffer_with_ctx(
+        &mut self,
+        max_length: usize,
+        device: DeviceID,
+    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+        // TODO: for now let's assume c plugins can never supply this data
+        // can be possible if we include it as an optional function that they can implement
+        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
     }
 
     fn device_info(&mut self) -> SDKResult<Vec<DeviceInfo>> {

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort, c_void};
 
 use crate::{
-    DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, Plugin, SDKResult, WootingAnalogResult,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, Plugin, SDKResult, WootingAnalogResult
 };
 
 macro_rules! lib_wrap {
@@ -159,7 +159,17 @@ impl Plugin for CPlugin {
     }
 
     fn read_analog(&mut self, code: u16, device: DeviceID) -> SDKResult<f32> {
-       self.read_analog(code, device)
+        self.read_analog(code, device)
+    }
+
+    fn read_analog_with_ctx(
+        &mut self,
+        _key_source: crate::KeySource,
+        _device_id: DeviceID,
+    ) -> SDKResult<AnalogValue> {
+        // TODO: for now let's assume c plugins can never supply this data
+        // can be possible if we include it as an optional function that they can implement
+        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
     }
 
     fn read_full_buffer(

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -6,7 +6,8 @@ use std::collections::HashMap;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort, c_void};
 
 use crate::{
-    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, PhysicalKey, Plugin, SDKResult, WootingAnalogResult
+    AnalogData, AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, Plugin,
+    SDKResult, WootingAnalogResult,
 };
 
 macro_rules! lib_wrap {
@@ -208,9 +209,9 @@ impl Plugin for CPlugin {
 
     fn read_full_buffer_with_ctx(
         &mut self,
-        max_length: usize,
-        device: DeviceID,
-    ) -> SDKResult<Vec<PhysicalKey>> {
+        _max_length: usize,
+        _device: DeviceID,
+    ) -> SDKResult<AnalogData> {
         // TODO: for now let's assume c plugins can never supply this data
         // can be possible if we include it as an optional function that they can implement
         SDKResult(Err(WootingAnalogResult::FunctionNotFound))

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -168,8 +168,8 @@ impl Plugin for CPlugin {
         _code: crate::KeyCode,
         _device_id: DeviceID,
     ) -> SDKResult<AnalogValue> {
-        // TODO: for now let's assume c plugins can never supply this data
-        // can be possible if we include it as an optional function that they can implement
+        // TODO: for now let's assume c plugins can not yet supply this data
+        // can easily be included via an optional fn in plugin.h 
         SDKResult(Err(WootingAnalogResult::FunctionNotFound))
     }
 
@@ -178,8 +178,8 @@ impl Plugin for CPlugin {
         _position: crate::KeyPosition,
         _device_id: DeviceID,
     ) -> SDKResult<crate::PhysicalKey> {
-        // TODO: for now let's assume c plugins can never supply this data
-        // can be possible if we include it as an optional function that they can implement
+        // TODO: for now let's assume c plugins can not yet supply this data
+        // can easily be included via an optional fn in plugin.h 
         SDKResult(Err(WootingAnalogResult::FunctionNotFound))
     }
 

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -3,8 +3,10 @@ use crate::DeviceEventType;
 use crate::DeviceID;
 use crate::DeviceInfo;
 use crate::KeyCode;
+use crate::KeyPosition;
 use crate::KeySource;
 use crate::KeycodeType;
+use crate::PhysicalKey;
 use crate::Plugin;
 use crate::SDKResult;
 use crate::WootingAnalogResult;
@@ -508,41 +510,40 @@ impl AnalogSDK {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+    ) -> SDKResult<Vec<PhysicalKey>> {
         if !self.initialised {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
 
-        let mut analog_data = HashMap::with_capacity(max_length);
+        let mut map: HashMap<KeyPosition, PhysicalKey> = HashMap::with_capacity(max_length);
 
         let mut err = WootingAnalogResult::Ok;
         let mut any_success = false;
         //Read from all and add up
         for p in self.plugins.iter_mut() {
             // Check if we've already collected enough data
-            if analog_data.len() >= max_length {
+            if map.len() >= max_length {
                 break;
             }
 
-            let remaining = max_length.saturating_sub(analog_data.len());
-            let plugin_data = p.read_full_buffer_with_ctx(remaining, device_id).into();
+            let remaining = max_length.saturating_sub(map.len());
+            let plugin_data: Result<Vec<PhysicalKey>, WootingAnalogResult> = p.read_full_buffer_with_ctx(remaining, device_id).into();
             match plugin_data {
-                Ok(mut data) => {
-                    for (mut k, v) in data.drain() {
-                        match hid_to_code(k, &self.keycode_mode) {
-                            Some(code) => k.inner = code,
-                            None => warn!("Couldn't map HID:{:?} to {:?}", k, self.keycode_mode),
-                        }
-                        
-                        let mut total_analog = v;
-
+                Ok(physical_keys) => {
+                    for pk in physical_keys {
                         //No point in checking if the value is already present if we are only looking for data from one device
                         if device_id == 0 {
-                            if let Some(val) = analog_data.get(&k) {
-                                total_analog = total_analog.max(*val);
-                            }
+                            let pk_max = pk.max_value();
+                            map.entry(pk.pos)
+                                .and_modify(|existing| {
+                                    if pk_max > existing.max_value() {
+                                        *existing = pk;
+                                    }
+                                })
+                                .or_insert(pk);
+                        } else {
+                            map.insert(pk.pos, pk);
                         }
-                        analog_data.insert(k, total_analog);
                     }
 
                     any_success = true;
@@ -561,7 +562,7 @@ impl AnalogSDK {
             return Err(err).into();
         }
 
-        Ok(analog_data).into()
+        Ok(map.into_values().collect()).into()
     }
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -1,6 +1,9 @@
+use crate::AnalogValue;
 use crate::DeviceEventType;
 use crate::DeviceID;
 use crate::DeviceInfo;
+use crate::KeyCode;
+use crate::KeySource;
 use crate::KeycodeType;
 use crate::Plugin;
 use crate::SDKResult;
@@ -400,6 +403,46 @@ impl AnalogSDK {
         }
     }
 
+    pub fn read_analog_with_ctx(
+        &mut self,
+        mut key_source: KeySource,
+        device_id: DeviceID,
+    ) -> SDKResult<AnalogValue> {
+        if !self.initialised {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        //Try and map the given keycode to HID
+        if let KeySource::Code(ref mut code) = key_source {
+            match code_to_hid(*code, &self.keycode_mode) {
+                Some(hid_code) => *code = hid_code,
+                None => return SDKResult(Err(WootingAnalogResult::NoMapping)),
+            }
+        }
+
+        let mut value = AnalogValue::from(-1.0);
+        let mut err = WootingAnalogResult::Ok;
+
+        for p in self.plugins.iter_mut() {
+            match p.read_analog_with_ctx(key_source, device_id).into() {
+                Ok(x) => {
+                    value = value.max(x);
+                    //If we were looking to read from a specific device, we've found that read, so no need to continue
+                    if device_id != 0 {
+                        break;
+                    }
+                }
+                Err(e) => err = e,
+            }
+        }
+
+        if value < 0.0 {
+            return Err(err).into();
+        }
+
+        SDKResult(Ok(value))
+    }
+
     pub fn read_full_buffer(
         &mut self,
         max_length: usize,
@@ -458,6 +501,14 @@ impl AnalogSDK {
         }
 
         Ok(analog_data).into()
+    }
+
+    pub fn read_full_buffer_with_ctx(
+        &mut self,
+        max_length: usize,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+        todo!()
     }
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -413,7 +413,7 @@ impl AnalogSDK {
         }
 
         //Try and map the given keycode to HID
-        if let KeySource::Code(ref mut code) = key_source {
+        if let KeySource::Raw(ref mut code) = key_source {
             match code_to_hid(*code, &self.keycode_mode) {
                 Some(hid_code) => *code = hid_code,
                 None => return SDKResult(Err(WootingAnalogResult::NoMapping)),
@@ -443,6 +443,7 @@ impl AnalogSDK {
         SDKResult(Ok(value))
     }
 
+    // TODO: call read_full_buffer_with_ctx and map over result ?
     pub fn read_full_buffer(
         &mut self,
         max_length: usize,
@@ -508,7 +509,59 @@ impl AnalogSDK {
         max_length: usize,
         device_id: DeviceID,
     ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
-        todo!()
+        if !self.initialised {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        let mut analog_data = HashMap::with_capacity(max_length);
+
+        let mut err = WootingAnalogResult::Ok;
+        let mut any_success = false;
+        //Read from all and add up
+        for p in self.plugins.iter_mut() {
+            // Check if we've already collected enough data
+            if analog_data.len() >= max_length {
+                break;
+            }
+
+            let remaining = max_length.saturating_sub(analog_data.len());
+            let plugin_data = p.read_full_buffer_with_ctx(remaining, device_id).into();
+            match plugin_data {
+                Ok(mut data) => {
+                    for (mut k, v) in data.drain() {
+                        match hid_to_code(k, &self.keycode_mode) {
+                            Some(code) => k.inner = code,
+                            None => warn!("Couldn't map HID:{:?} to {:?}", k, self.keycode_mode),
+                        }
+                        
+                        let mut total_analog = v;
+
+                        //No point in checking if the value is already present if we are only looking for data from one device
+                        if device_id == 0 {
+                            if let Some(val) = analog_data.get(&k) {
+                                total_analog = total_analog.max(*val);
+                            }
+                        }
+                        analog_data.insert(k, total_analog);
+                    }
+
+                    any_success = true;
+                }
+                Err(e) => {
+                    //TODO: Improve collating of multiple errors
+                    err = e
+                }
+            }
+            //If we are looking for a specific device, just break out when we find one that returns good
+            if device_id != 0 {
+                break;
+            }
+        }
+        if !any_success {
+            return Err(err).into();
+        }
+
+        Ok(analog_data).into()
     }
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -9,6 +9,7 @@ use crate::KeycodeType;
 use crate::PhysicalKey;
 use crate::Plugin;
 use crate::SDKResult;
+use crate::AnalogData;
 use crate::WootingAnalogResult;
 use crate::keycode::*;
 use crate::plugin::ANALOG_SDK_PLUGIN_VERSION;
@@ -510,59 +511,42 @@ impl AnalogSDK {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<Vec<PhysicalKey>> {
+    ) -> SDKResult<AnalogData> {
         if !self.initialised {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
 
-        let mut map: HashMap<KeyPosition, PhysicalKey> = HashMap::with_capacity(max_length);
-
+        let mut combined = AnalogData::new();
         let mut err = WootingAnalogResult::Ok;
         let mut any_success = false;
-        //Read from all and add up
+
         for p in self.plugins.iter_mut() {
-            // Check if we've already collected enough data
-            if map.len() >= max_length {
+            if combined.len() >= max_length {
                 break;
             }
 
-            let remaining = max_length.saturating_sub(map.len());
-            let plugin_data: Result<Vec<PhysicalKey>, WootingAnalogResult> = p.read_full_buffer_with_ctx(remaining, device_id).into();
-            match plugin_data {
-                Ok(physical_keys) => {
-                    for pk in physical_keys {
-                        //No point in checking if the value is already present if we are only looking for data from one device
-                        if device_id == 0 {
-                            let pk_max = pk.max_value();
-                            map.entry(pk.pos)
-                                .and_modify(|existing| {
-                                    if pk_max > existing.max_value() {
-                                        *existing = pk;
-                                    }
-                                })
-                                .or_insert(pk);
-                        } else {
-                            map.insert(pk.pos, pk);
-                        }
-                    }
-
+            let remaining = max_length.saturating_sub(combined.len());
+            match p.read_full_buffer_with_ctx(remaining, device_id).into() {
+                Ok(plugin_data) => {
+                    combined.merge(plugin_data);
                     any_success = true;
                 }
                 Err(e) => {
-                    //TODO: Improve collating of multiple errors
-                    err = e
+                    err = e;
                 }
             }
-            //If we are looking for a specific device, just break out when we find one that returns good
-            if device_id != 0 {
+
+            // If looking for a specific device, break after first successful read
+            if device_id != 0 && any_success {
                 break;
             }
         }
+
         if !any_success {
             return Err(err).into();
         }
 
-        Ok(map.into_values().collect()).into()
+        Ok(combined).into()
     }
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -1,15 +1,14 @@
+use crate::AnalogData;
 use crate::AnalogValue;
 use crate::DeviceEventType;
 use crate::DeviceID;
 use crate::DeviceInfo;
 use crate::KeyCode;
 use crate::KeyPosition;
-use crate::KeySource;
 use crate::KeycodeType;
 use crate::PhysicalKey;
 use crate::Plugin;
 use crate::SDKResult;
-use crate::AnalogData;
 use crate::WootingAnalogResult;
 use crate::keycode::*;
 use crate::plugin::ANALOG_SDK_PLUGIN_VERSION;
@@ -406,47 +405,6 @@ impl AnalogSDK {
         }
     }
 
-    pub fn read_analog_with_ctx(
-        &mut self,
-        mut key_source: KeySource,
-        device_id: DeviceID,
-    ) -> SDKResult<AnalogValue> {
-        if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
-        }
-
-        //Try and map the given keycode to HID
-        if let KeySource::Raw(ref mut code) = key_source {
-            match code_to_hid(*code, &self.keycode_mode) {
-                Some(hid_code) => *code = hid_code,
-                None => return SDKResult(Err(WootingAnalogResult::NoMapping)),
-            }
-        }
-
-        let mut value = AnalogValue::from(-1.0);
-        let mut err = WootingAnalogResult::Ok;
-
-        for p in self.plugins.iter_mut() {
-            match p.read_analog_with_ctx(key_source, device_id).into() {
-                Ok(x) => {
-                    value = value.max(x);
-                    //If we were looking to read from a specific device, we've found that read, so no need to continue
-                    if device_id != 0 {
-                        break;
-                    }
-                }
-                Err(e) => err = e,
-            }
-        }
-
-        if value < 0.0 {
-            return Err(err).into();
-        }
-
-        SDKResult(Ok(value))
-    }
-
-    // TODO: call read_full_buffer_with_ctx and map over result ?
     pub fn read_full_buffer(
         &mut self,
         max_length: usize,
@@ -507,11 +465,71 @@ impl AnalogSDK {
         Ok(analog_data).into()
     }
 
-    pub fn read_full_buffer_with_ctx(
+    pub fn read_keycode(&mut self, code: u16, device_id: DeviceID) -> SDKResult<AnalogValue> {
+        if !self.initialised {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        let Some(hid_code) = crate::keycode::code_to_hid(code, &self.keycode_mode) else {
+            return Err(WootingAnalogResult::NoMapping).into();
+        };
+
+        let mut value = AnalogValue::from(-1.0);
+        let mut err = WootingAnalogResult::Ok;
+
+        for p in self.plugins.iter_mut() {
+            match p.read_keycode(KeyCode::from(hid_code), device_id).into() {
+                Ok(x) => {
+                    value = value.max(x);
+                    if device_id != 0 {
+                        break;
+                    }
+                }
+                Err(e) => err = e,
+            }
+        }
+
+        if value < 0.0 {
+            return Err(err).into();
+        }
+
+        SDKResult(Ok(value))
+    }
+
+    pub fn read_position(
         &mut self,
-        max_length: usize,
+        position: KeyPosition,
         device_id: DeviceID,
-    ) -> SDKResult<AnalogData> {
+    ) -> SDKResult<PhysicalKey> {
+        if !self.initialised {
+            return Err(WootingAnalogResult::UnInitialized).into();
+        }
+
+        let mut result = PhysicalKey::new(position);
+        let mut err = WootingAnalogResult::Ok;
+
+        for p in self.plugins.iter_mut() {
+            match p.read_position(position, device_id).into() {
+                Ok(pk) => {
+                    for i in 0..pk.state_count {
+                        result.push_state(pk.states[i as usize]);
+                    }
+                    if device_id != 0 {
+                        break;
+                    }
+                }
+                Err(e) => err = e,
+            }
+        }
+
+        if result.state_count == 0 {
+            return Err(err).into();
+        }
+
+        SDKResult(Ok(result))
+    }
+
+    pub(crate) fn inputs(&mut self, device_id: DeviceID) -> SDKResult<AnalogData> {
         if !self.initialised {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
@@ -521,12 +539,7 @@ impl AnalogSDK {
         let mut any_success = false;
 
         for p in self.plugins.iter_mut() {
-            if combined.len() >= max_length {
-                break;
-            }
-
-            let remaining = max_length.saturating_sub(combined.len());
-            match p.read_full_buffer_with_ctx(remaining, device_id).into() {
+            match p.read_full_buffer_with_ctx(device_id).into() {
                 Ok(plugin_data) => {
                     combined.merge(plugin_data);
                     any_success = true;
@@ -547,6 +560,32 @@ impl AnalogSDK {
         }
 
         Ok(combined).into()
+    }
+
+    // TODO: hide hashmap impl detail behind opaque struct
+    // will probably be -> InputsPosition { .. }
+    // could even try Inputs<Position> ?
+    pub fn read_positions(
+        &mut self,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyPosition, PhysicalKey>> {
+        self.inputs(device_id)
+            .0
+            .map(|data| data.position_based)
+            .into()
+    }
+
+    // TODO: hide hashmap impl detail behind opaque struct
+    // will probably be -> InputsKeyCode { .. }
+    // could even try Inputs<KeyCode> ?
+    pub fn read_keycodes(
+        &mut self,
+        device_id: DeviceID,
+    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
+        self.inputs(device_id)
+            .0
+            .map(|data| data.keycode_based)
+            .into()
     }
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -465,7 +465,7 @@ impl AnalogSDK {
         Ok(analog_data).into()
     }
 
-    pub fn read_keycode(&mut self, code: u16, device_id: DeviceID) -> SDKResult<AnalogValue> {
+    pub(crate) fn read_keycode(&mut self, code: u16, device_id: DeviceID) -> SDKResult<AnalogValue> {
         if !self.initialised {
             return Err(WootingAnalogResult::UnInitialized).into();
         }
@@ -496,7 +496,7 @@ impl AnalogSDK {
         SDKResult(Ok(value))
     }
 
-    pub fn read_position(
+    pub(crate) fn read_position(
         &mut self,
         position: KeyPosition,
         device_id: DeviceID,
@@ -565,7 +565,7 @@ impl AnalogSDK {
     // TODO: hide hashmap impl detail behind opaque struct
     // will probably be -> InputsPosition { .. }
     // could even try Inputs<Position> ?
-    pub fn read_positions(
+    pub(crate) fn read_positions(
         &mut self,
         device_id: DeviceID,
     ) -> SDKResult<HashMap<KeyPosition, PhysicalKey>> {
@@ -578,7 +578,7 @@ impl AnalogSDK {
     // TODO: hide hashmap impl detail behind opaque struct
     // will probably be -> InputsKeyCode { .. }
     // could even try Inputs<KeyCode> ?
-    pub fn read_keycodes(
+    pub(crate) fn read_keycodes(
         &mut self,
         device_id: DeviceID,
     ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {


### PR DESCRIPTION
Introduces functions that give the consumer access to the recently added protocol context.
- Reading a single value can be done via keycode or matrix position, returning either the new `AnalogValue` type or `PhysicalKey` respectively. 
- Reading multiple values returns a list of those same types.
- The `AnalogValue` struct will contain the inner float value with a metadata if available.
- The `PhysicalKey` struct will contain the matrix position with all the active keys and their values, including metadata for both keys and values.

> [!NOTE]  
> The Rust API is still under construction and will heavily change after this will be merged, you can safely ignore most things in `lib.rs` and `sdk.rs` for now. 
>
> I consider the design of the FFI signatures pretty final though, so this deserves some extra care in a review.