### PR TITLE
Error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,12 +150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5611,7 +5605,6 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 name = "wooting-analog-sdk"
 version = "0.9.1"
 dependencies = [
- "anyhow",
  "bimap",
  "cmake",
  "dyn-clone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/WootingKb/wooting-analog-sdk"
 homepage = "https://github.com/WootingKb/wooting-analog-sdk"
 keywords = ["wooting", "keyboard", "analog", "sdk"]
 publish = false
-rust-version = "1.85.1"
+rust-version = "1.88.0"
 
 [workspace.dependencies]
 log = "0.4"

--- a/wooting-analog-sdk/Cargo.toml
+++ b/wooting-analog-sdk/Cargo.toml
@@ -23,7 +23,6 @@ shared_memory = { workspace = true, optional = true }
 enum-primitive-derive = "0.3"
 libloading = "0.8"
 thiserror = "2"
-anyhow = "1"
 num-traits = "0.2"
 ffi-support = "0.4"
 scancode = "0.1"

--- a/wooting-analog-sdk/cbindgen.toml
+++ b/wooting-analog-sdk/cbindgen.toml
@@ -16,10 +16,6 @@ include = [
     "DeviceType",
     "MAX_KEY_STATES",
 ]
-exclude = [
-    "_plugin_create",
-    "plugin_version",
-]
 prefix = "WootingAnalog_"
 renaming_overrides_prefixing = true
 item_types = ["enums", "structs", "typedefs", "functions", "opaque", "constants"]

--- a/wooting-analog-sdk/src/err.rs
+++ b/wooting-analog-sdk/src/err.rs
@@ -1,11 +1,111 @@
 use enum_primitive_derive::Primitive;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::ffi::{c_float, c_int};
+use std::{ffi::c_int, path::PathBuf};
 use thiserror::Error;
 
-pub type WootingResult<T> = std::result::Result<T, WootingAnalogResult>;
+use crate::{DeviceID, KeycodeType};
 
+#[derive(Error, Debug)]
+pub enum DelegateError {
+    #[error("dll not found")]
+    DllNotFound,
+
+    #[error("incompatible system version dll")]
+    IncompatibleSystemDll,
+}
+
+#[derive(Error, Debug)]
+pub enum PluginError {
+    #[error("plugin failed to call \"{0}\": function not found")]
+    FunctionUnavailable(&'static str),
+
+    #[error(
+        "plugin with version {version} is incompatible with the current SDK version ({expected})"
+    )]
+    VersionMismatch { version: u32, expected: u32 },
+
+    #[error("file \"{0:?}\" is not a valid plugin")]
+    InvalidPlugin(PathBuf),
+
+    #[error("path \"{0:?}\" is not a valid plugin directory")]
+    InvalidDirectory(PathBuf),
+
+    #[error("failed to read plugin directory: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("failed to load dll")]
+    DynamicLibraryError {
+        #[source]
+        source: libloading::Error,
+    },
+
+    #[error("zero plugins available")]
+    ZeroPlugins,
+}
+
+// TODO: refine this more after we've refactored the SDK struct
+// the uninit error will most likely go away
+#[derive(Error, Debug)]
+pub enum ReadError {
+    #[error("SDK was not initialized")]
+    Uninitialized,
+
+    #[error("keycode {keycode} does not map to any HID code using {mode:?} mode")]
+    NoMapping { keycode: u16, mode: KeycodeType },
+
+    #[error(transparent)]
+    Device(#[from] DeviceError),
+
+    #[error(transparent)]
+    Plugin(#[from] PluginError),
+}
+
+#[derive(Error, Debug)]
+pub enum DeviceErrorKind {
+    #[error("device disconnected")]
+    Disconnected,
+
+    #[error("unable to fetch devices")]
+    ZeroDevices,
+}
+
+#[derive(Error, Debug)]
+pub struct DeviceError {
+    pub kind: DeviceErrorKind,
+    pub device_id: Option<DeviceID>,
+}
+
+impl DeviceError {
+    pub fn disconnected(id: Option<DeviceID>) -> Self {
+        Self {
+            kind: DeviceErrorKind::Disconnected,
+            device_id: id,
+        }
+    }
+
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self.kind, DeviceErrorKind::Disconnected)
+    }
+
+    pub fn zero_devices() -> Self {
+        Self {
+            kind: DeviceErrorKind::ZeroDevices,
+            device_id: None,
+        }
+    }
+}
+
+impl std::fmt::Display for DeviceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.device_id {
+            Some(id) => write!(f, "{} (id: {id})", self.kind),
+            None => write!(f, "{}", self.kind),
+        }
+    }
+}
+
+// TODO: format errors (remove capitalization)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Default, PartialEq, Clone, Primitive, Error, Copy)]
 #[repr(C)]
@@ -76,37 +176,24 @@ impl From<WootingAnalogResult> for f32 {
     }
 }
 
-impl<T> From<WootingResult<T>> for WootingAnalogResult {
-    fn from(result: WootingResult<T>) -> Self {
-        match result {
-            Ok(_) => WootingAnalogResult::Ok,
-            Err(err) => err,
-        }
-    }
-}
-
-pub(crate) trait IntoFfiCount {
-    fn into_ffi_count(self) -> c_int;
-}
-
-impl IntoFfiCount for WootingResult<u32> {
-    fn into_ffi_count(self) -> c_int {
-        match self {
-            Ok(count) => count as c_int,
-            Err(err) => err as c_int,
-        }
-    }
-}
-
-pub(crate) trait IntoFfiAnalogValue {
-    fn into_ffi_analog_value(self) -> c_float;
-}
-
-impl IntoFfiAnalogValue for WootingResult<f32> {
-    fn into_ffi_analog_value(self) -> c_float {
-        match self {
-            Ok(value) => value as c_float,
-            Err(err) => (err as i32) as c_float,
+impl From<ReadError> for WootingAnalogResult {
+    fn from(err: ReadError) -> Self {
+        match err {
+            ReadError::Uninitialized => Self::UnInitialized,
+            ReadError::NoMapping { .. } => Self::NoMapping,
+            ReadError::Device(device_error) => match device_error.kind {
+                DeviceErrorKind::Disconnected => Self::DeviceDisconnected,
+                DeviceErrorKind::ZeroDevices => Self::NoDevices,
+            },
+            ReadError::Plugin(plugin_error) => match plugin_error {
+                PluginError::FunctionUnavailable(_) => Self::FunctionNotFound,
+                PluginError::VersionMismatch { .. } => Self::IncompatibleVersion,
+                PluginError::InvalidPlugin(_)
+                | PluginError::InvalidDirectory(_)
+                | PluginError::IoError(_)
+                | PluginError::ZeroPlugins => Self::NoPlugins,
+                PluginError::DynamicLibraryError { .. } => Self::NotAvailable,
+            },
         }
     }
 }

--- a/wooting-analog-sdk/src/err.rs
+++ b/wooting-analog-sdk/src/err.rs
@@ -1,0 +1,112 @@
+use enum_primitive_derive::Primitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use std::ffi::{c_float, c_int};
+use thiserror::Error;
+
+pub type WootingResult<T> = std::result::Result<T, WootingAnalogResult>;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Default, PartialEq, Clone, Primitive, Error, Copy)]
+#[repr(C)]
+pub enum WootingAnalogResult {
+    #[error("All OK")]
+    Ok = 1,
+    /// Item hasn't been initialized
+    #[error("SDK has not been initialized")]
+    UnInitialized = -2000isize,
+    /// No Devices are connected
+    #[error("No Devices are connected")]
+    NoDevices = -1999isize,
+    /// Device has been disconnected
+    #[error("Device has been disconnected")]
+    DeviceDisconnected = -1998isize,
+    /// Generic Failure
+    #[error("Generic Failure")]
+    Failure = -1997isize,
+    /// A given parameter was invalid
+    #[error("A given parameter was invalid")]
+    InvalidArgument = -1996isize,
+    /// No Plugins were found
+    #[error("No Plugins were found")]
+    NoPlugins = -1995isize,
+    /// The specified function was not found in the library
+    #[error("The specified function was not found in the library")]
+    #[default]
+    FunctionNotFound = -1994isize,
+    /// No Keycode mapping to HID was found for the given Keycode
+    #[error("No Keycode mapping to HID was found for the given Keycode")]
+    NoMapping = -1993isize,
+    /// Indicates that it isn't available on this platform
+    #[error("Unavailable on this platform")]
+    NotAvailable = -1992isize,
+    /// Indicates that the operation that is trying to be used is for an older version
+    #[error("Incompatible SDK Version")]
+    IncompatibleVersion = -1991isize,
+    /// Indicates that the Analog SDK could not be found on the system
+    #[error("The Wooting Analog SDK could not be found on the system")]
+    DLLNotFound = -1990isize,
+}
+
+impl WootingAnalogResult {
+    pub fn is_ok(&self) -> bool {
+        *self == WootingAnalogResult::Ok
+    }
+
+    pub fn is_ok_or_no_device(&self) -> bool {
+        *self == WootingAnalogResult::Ok || *self == WootingAnalogResult::NoDevices
+    }
+}
+
+impl From<WootingAnalogResult> for c_int {
+    fn from(value: WootingAnalogResult) -> Self {
+        value as c_int
+    }
+}
+
+impl From<WootingAnalogResult> for bool {
+    fn from(value: WootingAnalogResult) -> Self {
+        value == WootingAnalogResult::Ok
+    }
+}
+
+impl From<WootingAnalogResult> for f32 {
+    fn from(value: WootingAnalogResult) -> Self {
+        (value as i32) as f32
+    }
+}
+
+impl<T> From<WootingResult<T>> for WootingAnalogResult {
+    fn from(result: WootingResult<T>) -> Self {
+        match result {
+            Ok(_) => WootingAnalogResult::Ok,
+            Err(err) => err,
+        }
+    }
+}
+
+pub(crate) trait IntoFfiCount {
+    fn into_ffi_count(self) -> c_int;
+}
+
+impl IntoFfiCount for WootingResult<u32> {
+    fn into_ffi_count(self) -> c_int {
+        match self {
+            Ok(count) => count as c_int,
+            Err(err) => err as c_int,
+        }
+    }
+}
+
+pub(crate) trait IntoFfiAnalogValue {
+    fn into_ffi_analog_value(self) -> c_float;
+}
+
+impl IntoFfiAnalogValue for WootingResult<f32> {
+    fn into_ffi_analog_value(self) -> c_float {
+        match self {
+            Ok(value) => value as c_float,
+            Err(err) => (err as i32) as c_float,
+        }
+    }
+}

--- a/wooting-analog-sdk/src/err.rs
+++ b/wooting-analog-sdk/src/err.rs
@@ -61,6 +61,12 @@ pub enum ReadError {
     Plugin(#[from] PluginError),
 }
 
+impl ReadError {
+    pub fn function_unavailable(name: &'static str) -> Self {
+        Self::Plugin(PluginError::FunctionUnavailable(name))
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum DeviceErrorKind {
     #[error("device disconnected")]

--- a/wooting-analog-sdk/src/err.rs
+++ b/wooting-analog-sdk/src/err.rs
@@ -72,8 +72,8 @@ pub enum DeviceErrorKind {
 
 #[derive(Error, Debug)]
 pub struct DeviceError {
-    pub kind: DeviceErrorKind,
-    pub device_id: Option<DeviceID>,
+    pub(crate) kind: DeviceErrorKind,
+    pub(crate) device_id: Option<DeviceID>,
 }
 
 impl DeviceError {
@@ -93,6 +93,14 @@ impl DeviceError {
             kind: DeviceErrorKind::ZeroDevices,
             device_id: None,
         }
+    }
+
+    pub fn kind(&self) -> &DeviceErrorKind {
+        &self.kind
+    }
+
+    pub fn device_id(&self) -> Option<&DeviceID> {
+        self.device_id.as_ref()
     }
 }
 
@@ -181,19 +189,31 @@ impl From<ReadError> for WootingAnalogResult {
         match err {
             ReadError::Uninitialized => Self::UnInitialized,
             ReadError::NoMapping { .. } => Self::NoMapping,
-            ReadError::Device(device_error) => match device_error.kind {
-                DeviceErrorKind::Disconnected => Self::DeviceDisconnected,
-                DeviceErrorKind::ZeroDevices => Self::NoDevices,
-            },
-            ReadError::Plugin(plugin_error) => match plugin_error {
-                PluginError::FunctionUnavailable(_) => Self::FunctionNotFound,
-                PluginError::VersionMismatch { .. } => Self::IncompatibleVersion,
-                PluginError::InvalidPlugin(_)
-                | PluginError::InvalidDirectory(_)
-                | PluginError::IoError(_)
-                | PluginError::ZeroPlugins => Self::NoPlugins,
-                PluginError::DynamicLibraryError { .. } => Self::NotAvailable,
-            },
+            ReadError::Device(device_error) => Self::from(device_error),
+            ReadError::Plugin(plugin_error) => Self::from(plugin_error),
+        }
+    }
+}
+
+impl From<PluginError> for WootingAnalogResult {
+    fn from(err: PluginError) -> Self {
+        match err {
+            PluginError::FunctionUnavailable(_) => Self::FunctionNotFound,
+            PluginError::VersionMismatch { .. } => Self::IncompatibleVersion,
+            PluginError::InvalidPlugin(_)
+            | PluginError::InvalidDirectory(_)
+            | PluginError::IoError(_)
+            | PluginError::ZeroPlugins => Self::NoPlugins,
+            PluginError::DynamicLibraryError { .. } => Self::NotAvailable,
+        }
+    }
+}
+
+impl From<DeviceError> for WootingAnalogResult {
+    fn from(err: DeviceError) -> Self {
+        match err.kind {
+            DeviceErrorKind::Disconnected => Self::DeviceDisconnected,
+            DeviceErrorKind::ZeroDevices => Self::NoDevices,
         }
     }
 }

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "dist")]
 mod delegate_sys;
 
+use crate::err::{IntoFfiAnalogValue, IntoFfiCount, WootingAnalogResult, WootingResult};
+use crate::sdk::AnalogSDK;
 use crate::{
     AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
     KeycodeType, PhysicalKey, SDKResult, WootingAnalogResult, sdk::*,
@@ -42,11 +44,11 @@ pub extern "C" fn wooting_analog_initialise() -> c_int {
 
     let result = panic::catch_unwind(|| {
         trace!("wooting_analog_initialise called");
-        ANALOG_SDK.lock().unwrap().initialise().into()
+        ANALOG_SDK.lock().unwrap().initialise()
     });
     trace!("catch unwind result: {:?}", result);
     match result {
-        Ok(c) => c,
+        Ok(c) => c.into_ffi_count(),
         Err(e) => {
             error!("An error occurred in wooting_analog_initialise: {:?}", e);
             WootingAnalogResult::Failure.into()
@@ -223,7 +225,7 @@ pub extern "C" fn wooting_analog_read_analog_device(
         .lock()
         .unwrap()
         .read_analog(code, device_id)
-        .into()
+        .into_ffi_analog_value()
 }
 
 #[unsafe(no_mangle)]
@@ -358,8 +360,8 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
         return delegate_sys::wooting_analog_get_connected_devices_info(buffer, len);
     }
 
-    let result: SDKResult<Vec<DeviceInfo>> = ANALOG_SDK.lock().unwrap().get_device_info();
-    match result.0 {
+    let result: WootingResult<Vec<DeviceInfo>> = ANALOG_SDK.lock().unwrap().get_device_info();
+    match result {
         Ok(mut devices) => {
             let device_no = (len as usize).min(devices.len());
 
@@ -480,7 +482,6 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
         .lock()
         .unwrap()
         .read_full_buffer(len as usize, device_id)
-        .0
     {
         Ok(analog_data) => {
             //Fill up given slices

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dist")]
 mod delegate_sys;
 
-use crate::err::{IntoFfiAnalogValue, IntoFfiCount, WootingAnalogResult, WootingResult};
+use crate::err::WootingAnalogResult;
 use crate::sdk::AnalogSDK;
 use crate::{
     AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
@@ -48,7 +48,10 @@ pub extern "C" fn wooting_analog_initialise() -> c_int {
     });
     trace!("catch unwind result: {:?}", result);
     match result {
-        Ok(c) => c.into_ffi_count(),
+        Ok(c) => match c {
+            Ok(c) => c as c_int,
+            Err(e) => WootingAnalogResult::from(e).into(),
+        },
         Err(e) => {
             error!("An error occurred in wooting_analog_initialise: {:?}", e);
             WootingAnalogResult::Failure.into()
@@ -221,11 +224,10 @@ pub extern "C" fn wooting_analog_read_analog_device(
         return delegate_sys::wooting_analog_read_analog_device(code, device_id);
     }
 
-    ANALOG_SDK
-        .lock()
-        .unwrap()
-        .read_analog(code, device_id)
-        .into_ffi_analog_value()
+    match ANALOG_SDK.lock().unwrap().read_analog(code, device_id) {
+        Ok(v) => v,
+        Err(e) => WootingAnalogResult::from(e).into(),
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -252,7 +254,7 @@ pub unsafe extern "C" fn wooting_analog_read_keycode_device(
             *out = v;
             WootingAnalogResult::Ok
         }
-        Err(e) => e,
+        Err(e) => WootingAnalogResult::from(e),
     }
 }
 
@@ -308,7 +310,7 @@ pub extern "C" fn wooting_analog_set_device_event_cb(
         return delegate_sys::wooting_analog_set_device_event_cb(cb);
     }
 
-    ANALOG_SDK
+    match ANALOG_SDK
         .lock()
         .unwrap()
         .set_device_event_cb(move |event, device: DeviceInfo| {
@@ -320,8 +322,10 @@ pub extern "C" fn wooting_analog_set_device_event_cb(
             unsafe {
                 drop(Box::from_raw(device_raw));
             }
-        })
-        .into()
+        }) {
+        Ok(_) => WootingAnalogResult::Ok,
+        Err(e) => WootingAnalogResult::from(e),
+    }
 }
 
 /// Clears the device event callback that has been set
@@ -336,7 +340,10 @@ pub extern "C" fn wooting_analog_clear_device_event_cb() -> WootingAnalogResult 
         return delegate_sys::wooting_analog_clear_device_event_cb();
     }
 
-    ANALOG_SDK.lock().unwrap().clear_device_event_cb().into()
+    match ANALOG_SDK.lock().unwrap().clear_device_event_cb() {
+        Ok(_) => WootingAnalogResult::Ok,
+        Err(e) => WootingAnalogResult::from(e),
+    }
 }
 
 thread_local!(static CONNECTED_DEVICES: RefCell<Option<Vec<*mut DeviceInfo_FFI>>> = RefCell::new(None));
@@ -360,8 +367,7 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
         return delegate_sys::wooting_analog_get_connected_devices_info(buffer, len);
     }
 
-    let result: WootingResult<Vec<DeviceInfo>> = ANALOG_SDK.lock().unwrap().get_device_info();
-    match result {
+    match ANALOG_SDK.lock().unwrap().get_device_info() {
         Ok(mut devices) => {
             let device_no = (len as usize).min(devices.len());
 
@@ -393,7 +399,7 @@ pub extern "C" fn wooting_analog_get_connected_devices_info(
             });
             device_no as i32
         }
-        Err(e) => e.into(),
+        Err(e) => WootingAnalogResult::from(e).into(),
     }
 }
 
@@ -497,7 +503,7 @@ pub extern "C" fn wooting_analog_read_full_buffer_device(
             }
             count as c_int
         }
-        Err(e) => e as c_int,
+        Err(e) => WootingAnalogResult::from(e) as c_int,
     }
 }
 
@@ -578,7 +584,7 @@ pub unsafe extern "C" fn wooting_analog_read_positions_device(
             }
             count as c_int
         }
-        Err(e) => e as c_int,
+        Err(e) => WootingAnalogResult::from(e) as c_int,
     }
 }
 

--- a/wooting-analog-sdk/src/ffi.rs
+++ b/wooting-analog-sdk/src/ffi.rs
@@ -1,11 +1,10 @@
 #[cfg(feature = "dist")]
 mod delegate_sys;
 
-use crate::err::WootingAnalogResult;
 use crate::sdk::AnalogSDK;
 use crate::{
     AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
-    KeycodeType, PhysicalKey, SDKResult, WootingAnalogResult, sdk::*,
+    KeycodeType, PhysicalKey, err::WootingAnalogResult,
 };
 #[cfg(feature = "dist")]
 use delegate_sys::USE_SYS_DLL;
@@ -241,12 +240,7 @@ pub unsafe extern "C" fn wooting_analog_read_keycode_device(
         return delegate_sys::wooting_analog_read_keycode_device(keycode, value, device_id);
     }
 
-    match ANALOG_SDK
-        .lock()
-        .unwrap()
-        .read_keycode(keycode, device_id)
-        .0
-    {
+    match ANALOG_SDK.lock().unwrap().read_keycode(keycode, device_id) {
         Ok(v) => {
             let Some(out) = (unsafe { value.as_mut() }) else {
                 return WootingAnalogResult::InvalidArgument;
@@ -278,7 +272,7 @@ pub unsafe extern "C" fn wooting_analog_read_position_device(
             return WootingAnalogResult::InvalidArgument;
         };
 
-        match ANALOG_SDK.lock().unwrap().read_position(*pos, device_id).0 {
+        match ANALOG_SDK.lock().unwrap().read_position(*pos, device_id) {
             Ok(pk) => {
                 let Some(out) = physical_key.as_mut() else {
                     return WootingAnalogResult::InvalidArgument;
@@ -286,7 +280,7 @@ pub unsafe extern "C" fn wooting_analog_read_position_device(
                 *out = pk;
                 WootingAnalogResult::Ok
             }
-            Err(e) => e,
+            Err(e) => WootingAnalogResult::from(e),
         }
     }
 }
@@ -536,7 +530,7 @@ pub unsafe extern "C" fn wooting_analog_read_keycodes_device(
         slice::from_raw_parts_mut(analog_buffer, len as usize)
     };
 
-    match ANALOG_SDK.lock().unwrap().read_keycodes(device_id).0 {
+    match ANALOG_SDK.lock().unwrap().read_keycodes(device_id) {
         Ok(analog_data) => {
             let mut count: usize = 0;
             for (k, v) in analog_data {
@@ -550,7 +544,7 @@ pub unsafe extern "C" fn wooting_analog_read_keycodes_device(
             }
             count as c_int
         }
-        Err(e) => e as c_int,
+        Err(e) => WootingAnalogResult::from(e) as c_int,
     }
 }
 
@@ -571,7 +565,7 @@ pub unsafe extern "C" fn wooting_analog_read_positions_device(
         slice::from_raw_parts_mut(physical_keys, len as usize)
     };
 
-    match ANALOG_SDK.lock().unwrap().read_positions(device_id).0 {
+    match ANALOG_SDK.lock().unwrap().read_positions(device_id) {
         Ok(analog_data) => {
             let mut count: usize = 0;
             for (_, k) in analog_data {

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -77,15 +77,15 @@ fn find_dll_in_path(filename: &str) -> Option<PathBuf> {
     search_env_var("PATH")
 }
 
-fn try_system_dll() -> WootingResult<()> {
+fn try_system_dll() -> Result<(), DelegateError> {
     if LIB.is_none() {
-        return Err(WootingAnalogResult::DLLNotFound);
+        return Err(DelegateError::DllNotFound);
     }
 
     if wooting_analog_version() == *SDK_VERSION {
         Ok(())
     } else {
-        Err(WootingAnalogResult::IncompatibleVersion)
+        Err(DelegateError::IncompatibleSystemDll)
     }
 }
 

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -1,6 +1,6 @@
 use crate::{
     AnalogValue, DeviceEventType, DeviceID, DeviceInfo_FFI, KeyCode, KeyPosition, PhysicalKey,
-    WootingAnalogResult,
+    err::{DelegateError, WootingAnalogResult},
 };
 use libloading::Symbol;
 use std::os::raw::{c_char, c_float, c_int, c_uint, c_ushort};

--- a/wooting-analog-sdk/src/ffi/delegate_sys.rs
+++ b/wooting-analog-sdk/src/ffi/delegate_sys.rs
@@ -77,7 +77,7 @@ fn find_dll_in_path(filename: &str) -> Option<PathBuf> {
     search_env_var("PATH")
 }
 
-fn try_system_dll() -> Result<(), WootingAnalogResult> {
+fn try_system_dll() -> WootingResult<()> {
     if LIB.is_none() {
         return Err(WootingAnalogResult::DLLNotFound);
     }

--- a/wooting-analog-sdk/src/lib.rs
+++ b/wooting-analog-sdk/src/lib.rs
@@ -1,3 +1,4 @@
+mod err;
 #[cfg(feature = "ffi")]
 pub mod ffi;
 pub mod keycode;
@@ -8,16 +9,13 @@ mod virtual_input;
 
 pub use crate::plugin::Plugin;
 use enum_primitive_derive::Primitive;
-use ffi_support::FfiStr;
 pub use num_traits::{FromPrimitive, ToPrimitive};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::hash::Hasher;
-use std::ops::Deref;
 use std::os::raw::{c_char, c_int};
-use thiserror::Error;
 
 /// The core `DeviceInfo` struct which contains all the interesting information
 /// for a particular device. This is for use internally and should be ignored if you're
@@ -548,199 +546,6 @@ pub enum DeviceEventType {
     Connected = 1,
     /// Device has been disconnected
     Disconnected = 2,
-}
-
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Clone, Primitive, Error, Copy)]
-#[repr(C)]
-pub enum WootingAnalogResult {
-    #[error("All OK")]
-    Ok = 1,
-    /// Item hasn't been initialized
-    #[error("SDK has not been initialized")]
-    UnInitialized = -2000isize,
-    /// No Devices are connected
-    #[error("No Devices are connected")]
-    NoDevices = -1999isize,
-    /// Device has been disconnected
-    #[error("Device has been disconnected")]
-    DeviceDisconnected = -1998isize,
-    /// Generic Failure
-    #[error("Generic Failure")]
-    Failure = -1997isize,
-    /// A given parameter was invalid
-    #[error("A given parameter was invalid")]
-    InvalidArgument = -1996isize,
-    /// No Plugins were found
-    #[error("No Plugins were found")]
-    NoPlugins = -1995isize,
-    /// The specified function was not found in the library
-    #[error("The specified function was not found in the library")]
-    FunctionNotFound = -1994isize,
-    /// No Keycode mapping to HID was found for the given Keycode
-    #[error("No Keycode mapping to HID was found for the given Keycode")]
-    NoMapping = -1993isize,
-    /// Indicates that it isn't available on this platform
-    #[error("Unavailable on this platform")]
-    NotAvailable = -1992isize,
-    /// Indicates that the operation that is trying to be used is for an older version
-    #[error("Incompatible SDK Version")]
-    IncompatibleVersion = -1991isize,
-    /// Indicates that the Analog SDK could not be found on the system
-    #[error("The Wooting Analog SDK could not be found on the system")]
-    DLLNotFound = -1990isize,
-}
-
-impl WootingAnalogResult {
-    pub fn is_ok(&self) -> bool {
-        *self == WootingAnalogResult::Ok
-    }
-
-    pub fn is_ok_or_no_device(&self) -> bool {
-        *self == WootingAnalogResult::Ok || *self == WootingAnalogResult::NoDevices
-    }
-}
-
-impl Default for WootingAnalogResult {
-    fn default() -> Self {
-        WootingAnalogResult::FunctionNotFound
-    }
-}
-
-#[derive(Debug)]
-pub struct SDKResult<T>(pub std::result::Result<T, WootingAnalogResult>);
-
-impl<T> Default for SDKResult<T> {
-    fn default() -> Self {
-        Err(Default::default()).into()
-    }
-}
-
-impl<T> Deref for SDKResult<T> {
-    type Target = std::result::Result<T, WootingAnalogResult>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> From<std::result::Result<T, WootingAnalogResult>> for SDKResult<T> {
-    fn from(ptr: std::result::Result<T, WootingAnalogResult>) -> Self {
-        SDKResult(ptr)
-    }
-}
-
-impl<T> Into<std::result::Result<T, WootingAnalogResult>> for SDKResult<T> {
-    fn into(self) -> std::result::Result<T, WootingAnalogResult> {
-        self.0
-    }
-}
-
-//TODO: Figure out a way to not have to use this for the lib_wrap_option in the sdk
-impl<'a> From<FfiStr<'a>> for SDKResult<FfiStr<'a>> {
-    fn from(res: FfiStr<'a>) -> Self {
-        Ok(res).into()
-    }
-}
-
-impl From<c_int> for SDKResult<c_int> {
-    fn from(res: c_int) -> Self {
-        if res >= 0 {
-            Ok(res).into()
-        } else {
-            Err(WootingAnalogResult::from_i32(res).unwrap_or(WootingAnalogResult::Failure)).into()
-        }
-    }
-}
-
-impl From<c_int> for SDKResult<u32> {
-    fn from(res: c_int) -> Self {
-        if res >= 0 {
-            Ok(res as u32).into()
-        } else {
-            Err(WootingAnalogResult::from_i32(res).unwrap_or(WootingAnalogResult::Failure)).into()
-        }
-    }
-}
-
-impl Into<c_int> for WootingAnalogResult {
-    fn into(self) -> c_int {
-        self as c_int
-    }
-}
-
-impl From<u32> for SDKResult<u32> {
-    fn from(res: u32) -> Self {
-        Ok(res).into()
-    }
-}
-
-impl Into<i32> for SDKResult<u32> {
-    fn into(self) -> i32 {
-        match self.0 {
-            Ok(v) => v as i32,
-            Err(e) => e.into(),
-        }
-    }
-}
-
-impl Into<c_int> for SDKResult<c_int> {
-    fn into(self) -> c_int {
-        match self.0 {
-            Ok(v) => v,
-            Err(e) => e.into(),
-        }
-    }
-}
-
-impl From<f32> for SDKResult<f32> {
-    fn from(res: f32) -> Self {
-        if res >= 0.0 {
-            Ok(res).into()
-        } else {
-            Err(WootingAnalogResult::from_f32(res).unwrap_or(WootingAnalogResult::Failure)).into()
-        }
-    }
-}
-
-impl Into<f32> for WootingAnalogResult {
-    fn into(self) -> f32 {
-        (self as i32) as f32
-    }
-}
-
-impl Into<f32> for SDKResult<f32> {
-    fn into(self) -> f32 {
-        match self.0 {
-            Ok(v) => v,
-            Err(e) => e.into(),
-        }
-    }
-}
-
-impl Into<WootingAnalogResult> for SDKResult<()> {
-    fn into(self) -> WootingAnalogResult {
-        match self.0 {
-            Ok(_) => WootingAnalogResult::Ok,
-            Err(e) => e,
-        }
-    }
-}
-
-impl From<WootingAnalogResult> for SDKResult<()> {
-    fn from(res: WootingAnalogResult) -> Self {
-        if res.is_ok() {
-            Ok(()).into()
-        } else {
-            Err(res).into()
-        }
-    }
-}
-
-impl Into<bool> for WootingAnalogResult {
-    fn into(self) -> bool {
-        self == WootingAnalogResult::Ok
-    }
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::{str, thread};
 
+use crate::err::{WootingAnalogResult, WootingResult};
 #[cfg(feature = "virtual-input")]
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
@@ -33,13 +34,13 @@ pub static ANALOG_SDK_PLUGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The core Plugin trait which needs to be implemented for an Analog Plugin to function
 pub trait Plugin {
     /// Get a name describing the `Plugin`.
-    fn name(&mut self) -> SDKResult<&'static str>;
+    fn name(&mut self) -> WootingResult<&'static str>;
 
     /// Initialise the plugin with the given function for device events. Returns an int indicating the number of connected devices
     fn initialise(
         &mut self,
         callback: Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
-    ) -> SDKResult<u32>;
+    ) -> WootingResult<u32>;
 
     /// A function fired to check if the plugin is currently initialised
     fn is_initialised(&mut self) -> bool;
@@ -50,7 +51,7 @@ pub trait Plugin {
     /// # Notes
     ///
     /// Although, the client should be copying any data they want to use for a prolonged time as there is no lifetime guarantee on the data.
-    fn device_info(&mut self) -> SDKResult<Vec<DeviceInfo>>;
+    fn device_info(&mut self) -> WootingResult<Vec<DeviceInfo>>;
 
     /// A callback fired immediately before the plugin is unloaded. Use this if
     /// you need to do any cleanup.
@@ -58,7 +59,7 @@ pub trait Plugin {
 
     /// Function called to get the analog value for a particular HID key `code` from the device with ID `device`.
     /// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
-    fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32>;
+    fn read_analog(&mut self, code: u16, device_id: DeviceID) -> WootingResult<f32>;
 
     fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue>;
 
@@ -75,7 +76,7 @@ pub trait Plugin {
         &mut self,
         max_length: usize,
         device: DeviceID,
-    ) -> SDKResult<HashMap<c_ushort, c_float>>;
+    ) -> WootingResult<HashMap<c_ushort, c_float>>;
 
     fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData>;
 
@@ -139,7 +140,7 @@ trait DeviceImplementation: DynClone + Send {
         &self,
         device: &HidDevice,
         max_length: usize,
-    ) -> SDKResult<Option<HashMap<c_ushort, c_float>>> {
+    ) -> WootingResult<Option<HashMap<c_ushort, c_float>>> {
         let mut buffer: [u8; ANALOG_BUFFER_SIZE_V1] = [0; ANALOG_BUFFER_SIZE_V1];
         let res = device.read_timeout(&mut buffer, 50);
 
@@ -147,13 +148,13 @@ trait DeviceImplementation: DynClone + Send {
             Ok(len) => {
                 // If the length is 0 then that means the read timed out, so we shouldn't use it to update values
                 if len == 0 {
-                    return Ok(None).into();
+                    return Ok(None);
                 }
             }
             Err(e) => {
                 error!("Failed to read buffer: {}", e);
 
-                return Err(WootingAnalogResult::DeviceDisconnected).into();
+                return Err(WootingAnalogResult::DeviceDisconnected);
             }
         }
         Ok(Some(
@@ -169,7 +170,6 @@ trait DeviceImplementation: DynClone + Send {
                 })
                 .collect(),
         ))
-        .into()
     }
 
     fn get_analog_buffer_with_ctx(
@@ -272,7 +272,8 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                 },
                 Err(e) => Err(e),
             },
-        )
+            Err(e) => Err(e),
+        }
     }
 
     fn get_analog_buffer_with_ctx(
@@ -287,13 +288,13 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
             Ok(len) => {
                 // If the length is 0 then that means the read timed out, so we shouldn't use it to update values
                 if len == 0 {
-                    return Ok(None).into();
+                    return Ok(None);
                 }
             }
             Err(e) => {
                 error!("Failed to read buffer: {}", e);
 
-                return Err(WootingAnalogResult::DeviceDisconnected).into();
+                return Err(WootingAnalogResult::DeviceDisconnected);
             }
         }
         Ok(Some(
@@ -331,7 +332,6 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                 })
                 .collect(),
         ))
-        .into()
     }
 
     fn analog_value_to_float(&self, value: u16) -> f32 {
@@ -372,10 +372,7 @@ impl Device {
 
                     match device_impl.device_hardware_id().usage_page {
                         ANALOG_INTERFACE_V1 => {
-                            match device_impl
-                                .get_analog_buffer(&device, ANALOG_MAX_SIZE)
-                                .into()
-                            {
+                            match device_impl.get_analog_buffer(&device, ANALOG_MAX_SIZE) {
                                 Ok(data) => {
                                     if let Some(data) = data {
                                         let mut map = t_buffer.lock().unwrap();
@@ -399,10 +396,7 @@ impl Device {
                             }
                         }
                         ANALOG_INTERFACE_V2 => {
-                            match device_impl
-                                .get_analog_buffer_with_ctx(&device, ANALOG_MAX_SIZE)
-                                .into()
-                            {
+                            match device_impl.get_analog_buffer_with_ctx(&device, ANALOG_MAX_SIZE) {
                                 Ok(data) => {
                                     if let Some(data) = data {
                                         let mut map = t_buffer.lock().unwrap();
@@ -503,7 +497,7 @@ impl Device {
         // Store only the currently pressed keys for the next call
         self.pressed_keys = new_pressed_keys;
 
-        Ok(buffer).into()
+        Ok(buffer)
     }
 }
 
@@ -542,7 +536,7 @@ impl WootingPlugin {
         }
     }
 
-    fn init_worker(&mut self) -> SDKResult<u32> {
+    fn init_worker(&mut self) -> WootingResult<u32> {
         let init_device_closure =
             |hid: &HidApi,
              devices: &Arc<Mutex<HashMap<DeviceID, Device>>>,
@@ -622,7 +616,7 @@ impl WootingPlugin {
             }
             Err(e) => {
                 error!("Error obtaining HIDAPI: {}", e);
-                return Err(WootingAnalogResult::Failure).into();
+                return Err(WootingAnalogResult::Failure);
             }
         };
 
@@ -671,7 +665,7 @@ impl WootingPlugin {
         self.virtual_keyboard.attach();
 
         debug!("Started thread");
-        Ok(self.devices.lock().unwrap().len() as u32).into()
+        Ok(self.devices.lock().unwrap().len() as u32)
     }
 
     #[unsafe(no_mangle)]
@@ -687,14 +681,14 @@ impl WootingPlugin {
 }
 
 impl Plugin for WootingPlugin {
-    fn name(&mut self) -> SDKResult<&'static str> {
-        Ok(PLUGIN_NAME).into()
+    fn name(&mut self) -> WootingResult<&'static str> {
+        Ok(PLUGIN_NAME)
     }
 
     fn initialise(
         &mut self,
         callback: Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
-    ) -> SDKResult<u32> {
+    ) -> WootingResult<u32> {
         if let Err(e) = env_logger::try_init() {
             warn!("Unable to initialize Env Logger: {}", e);
         }
@@ -740,11 +734,11 @@ impl Plugin for WootingPlugin {
 
     fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices).into();
+            return Err(WootingAnalogResult::NoDevices);
         }
 
         if device_id == 0 {
@@ -761,7 +755,7 @@ impl Plugin for WootingPlugin {
             if analog < 0.0 {
                 Err(error).into()
             } else {
-                SDKResult(Ok(analog))
+                Ok(analog)
             }
         } else {
             match self.devices.lock().unwrap().get_mut(&device_id) {
@@ -816,13 +810,13 @@ impl Plugin for WootingPlugin {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<c_ushort, c_float>> {
+    ) -> WootingResult<HashMap<c_ushort, c_float>> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices).into();
+            return Err(WootingAnalogResult::NoDevices);
         }
 
         //If the Device ID is 0 we want to go through all the connected devices
@@ -832,7 +826,7 @@ impl Plugin for WootingPlugin {
             let mut any_read = false;
             let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_full_with_ctx().into() {
+                match device.read_full_with_ctx() {
                     Ok(val) => {
                         for (k, v) in val.iter().map(|k| (k.code.as_u16(), k.value.as_f32())) {
                             analog
@@ -853,7 +847,7 @@ impl Plugin for WootingPlugin {
             }
 
             if !any_read {
-                Err(error).into()
+                Err(error)
             } else {
                 #[cfg(feature = "virtual-input")]
                 self.virtual_keyboard.iter_over(|iter| {
@@ -865,7 +859,7 @@ impl Plugin for WootingPlugin {
                     }
                 });
 
-                Ok(analog).into()
+                Ok(analog)
             }
         } else
         //If the device id is not 0, we try and find a connected device with that ID and read from it
@@ -879,18 +873,18 @@ impl Plugin for WootingPlugin {
                     .into(),
                     Err(e) => Err(e).into(),
                 },
-                None => Err(WootingAnalogResult::NoDevices).into(),
+                None => Err(WootingAnalogResult::NoDevices),
             }
         }
     }
 
     fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices).into();
+            return Err(WootingAnalogResult::NoDevices);
         }
 
         // If the Device ID is 0 we want to go through all the connected devices
@@ -914,7 +908,7 @@ impl Plugin for WootingPlugin {
             }
 
             if !any_read {
-                Err(error).into()
+                Err(error)
             } else {
                 // TODO: convert virtual keyboard to use KeyCode and AnalogValue
                 // #[cfg(feature = "virtual-input")]
@@ -1058,14 +1052,14 @@ impl Plugin for WootingPlugin {
                     Ok(keys) => Ok(AnalogData::from(keys).position_based).into(),
                     Err(e) => Err(e).into(),
                 },
-                None => Err(WootingAnalogResult::NoDevices).into(),
+                None => Err(WootingAnalogResult::NoDevices),
             }
         }
     }
 
-    fn device_info(&mut self) -> SDKResult<Vec<DeviceInfo>> {
+    fn device_info(&mut self) -> WootingResult<Vec<DeviceInfo>> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
 
         let mut devices = vec![];
@@ -1073,6 +1067,6 @@ impl Plugin for WootingPlugin {
             devices.push(device.device_info.clone());
         }
 
-        Ok(devices).into()
+        Ok(devices)
     }
 }

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::{str, thread};
 
-use crate::err::{WootingAnalogResult, WootingResult};
+use crate::err::{DeviceError, PluginError, ReadError};
 #[cfg(feature = "virtual-input")]
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
@@ -34,13 +34,13 @@ pub static ANALOG_SDK_PLUGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The core Plugin trait which needs to be implemented for an Analog Plugin to function
 pub trait Plugin {
     /// Get a name describing the `Plugin`.
-    fn name(&mut self) -> WootingResult<&'static str>;
+    fn name(&mut self) -> Result<&'static str, PluginError>;
 
     /// Initialise the plugin with the given function for device events. Returns an int indicating the number of connected devices
     fn initialise(
         &mut self,
         callback: Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
-    ) -> WootingResult<u32>;
+    ) -> Result<u32, ReadError>;
 
     /// A function fired to check if the plugin is currently initialised
     fn is_initialised(&mut self) -> bool;
@@ -51,7 +51,7 @@ pub trait Plugin {
     /// # Notes
     ///
     /// Although, the client should be copying any data they want to use for a prolonged time as there is no lifetime guarantee on the data.
-    fn device_info(&mut self) -> WootingResult<Vec<DeviceInfo>>;
+    fn device_info(&mut self) -> Result<Vec<DeviceInfo>, ReadError>;
 
     /// A callback fired immediately before the plugin is unloaded. Use this if
     /// you need to do any cleanup.
@@ -59,7 +59,7 @@ pub trait Plugin {
 
     /// Function called to get the analog value for a particular HID key `code` from the device with ID `device`.
     /// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
-    fn read_analog(&mut self, code: u16, device_id: DeviceID) -> WootingResult<f32>;
+    fn read_analog(&mut self, code: u16, device_id: DeviceID) -> Result<f32, ReadError>;
 
     fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue>;
 
@@ -76,7 +76,7 @@ pub trait Plugin {
         &mut self,
         max_length: usize,
         device: DeviceID,
-    ) -> WootingResult<HashMap<c_ushort, c_float>>;
+    ) -> Result<HashMap<c_ushort, c_float>, ReadError>;
 
     fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData>;
 
@@ -140,7 +140,7 @@ trait DeviceImplementation: DynClone + Send {
         &self,
         device: &HidDevice,
         max_length: usize,
-    ) -> WootingResult<Option<HashMap<c_ushort, c_float>>> {
+    ) -> Result<Option<HashMap<c_ushort, c_float>>, DeviceError> {
         let mut buffer: [u8; ANALOG_BUFFER_SIZE_V1] = [0; ANALOG_BUFFER_SIZE_V1];
         let res = device.read_timeout(&mut buffer, 50);
 
@@ -154,7 +154,7 @@ trait DeviceImplementation: DynClone + Send {
             Err(e) => {
                 error!("Failed to read buffer: {}", e);
 
-                return Err(WootingAnalogResult::DeviceDisconnected);
+                return Err(DeviceError::disconnected(None));
             }
         }
         Ok(Some(
@@ -294,14 +294,13 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
             Err(e) => {
                 error!("Failed to read buffer: {}", e);
 
-                return Err(WootingAnalogResult::DeviceDisconnected);
+                return Err(DeviceError::disconnected(None));
             }
         }
         Ok(Some(
             buffer
                 .chunks_exact(4)
                 .take(max_length)
-                .filter(|&b| b[3] != 0)
                 .map(|b| {
                     let matrix_pos = b[0];
                     let key = b[1];
@@ -330,6 +329,7 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                         ),
                     }
                 })
+                .filter(|(k, v)| k != &KeyCode::default() && v != &AnalogValue::default())
                 .collect(),
         ))
     }
@@ -384,7 +384,7 @@ impl Device {
                                     }
                                 }
                                 Err(e) => {
-                                    if e != WootingAnalogResult::DeviceDisconnected {
+                                    if !e.is_disconnected() {
                                         error!(
                                             "Read failed from device that isn't DeviceDisconnected, we got {:?}. Disconnecting device...",
                                             e
@@ -405,7 +405,7 @@ impl Device {
                                     }
                                 }
                                 Err(e) => {
-                                    if e != WootingAnalogResult::DeviceDisconnected {
+                                    if !e.is_disconnected() {
                                         error!(
                                             "Read failed from device that isn't DeviceDisconnected, we got {:?}. Disconnecting device...",
                                             e
@@ -536,7 +536,7 @@ impl WootingPlugin {
         }
     }
 
-    fn init_worker(&mut self) -> WootingResult<u32> {
+    fn init_worker(&mut self) -> Result<u32, DeviceError> {
         let init_device_closure =
             |hid: &HidApi,
              devices: &Arc<Mutex<HashMap<DeviceID, Device>>>,
@@ -616,7 +616,7 @@ impl WootingPlugin {
             }
             Err(e) => {
                 error!("Error obtaining HIDAPI: {}", e);
-                return Err(WootingAnalogResult::Failure);
+                return Err(DeviceError::zero_devices());
             }
         };
 
@@ -667,33 +667,22 @@ impl WootingPlugin {
         debug!("Started thread");
         Ok(self.devices.lock().unwrap().len() as u32)
     }
-
-    #[unsafe(no_mangle)]
-    pub extern "C" fn _plugin_create() -> *mut dyn Plugin {
-        let boxed: Box<dyn Plugin> = Box::new(Self::new());
-        Box::into_raw(boxed)
-    }
-
-    #[unsafe(no_mangle)]
-    pub extern "C" fn plugin_version() -> &'static str {
-        ANALOG_SDK_PLUGIN_VERSION
-    }
 }
 
 impl Plugin for WootingPlugin {
-    fn name(&mut self) -> WootingResult<&'static str> {
+    fn name(&mut self) -> Result<&'static str, PluginError> {
         Ok(PLUGIN_NAME)
     }
 
     fn initialise(
         &mut self,
         callback: Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
-    ) -> WootingResult<u32> {
+    ) -> Result<u32, ReadError> {
         if let Err(e) = env_logger::try_init() {
             warn!("Unable to initialize Env Logger: {}", e);
         }
 
-        let ret = self.init_worker();
+        let ret = self.init_worker()?;
 
         #[cfg(feature = "virtual-input")]
         {
@@ -707,8 +696,8 @@ impl Plugin for WootingPlugin {
             self.device_event_cb = Arc::new(Mutex::new(Some(callback)));
         }
 
-        self.initialised.store(ret.is_ok(), Ordering::Relaxed);
-        ret
+        self.initialised.store(true, Ordering::Relaxed);
+        Ok(ret)
     }
 
     fn is_initialised(&mut self) -> bool {
@@ -734,11 +723,11 @@ impl Plugin for WootingPlugin {
 
     fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices);
+            return Err(ReadError::Device(DeviceError::zero_devices()));
         }
 
         if device_id == 0 {
@@ -810,13 +799,13 @@ impl Plugin for WootingPlugin {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> WootingResult<HashMap<c_ushort, c_float>> {
+    ) -> Result<HashMap<c_ushort, c_float>, ReadError> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices);
+            return Err(ReadError::Device(DeviceError::zero_devices()));
         }
 
         //If the Device ID is 0 we want to go through all the connected devices
@@ -824,7 +813,7 @@ impl Plugin for WootingPlugin {
         if device_id == 0 {
             let mut analog: HashMap<c_ushort, c_float> = HashMap::new();
             let mut any_read = false;
-            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+            let mut error = None;
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
                 match device.read_full_with_ctx() {
                     Ok(val) => {
@@ -841,26 +830,28 @@ impl Plugin for WootingPlugin {
                         any_read = true;
                     }
                     Err(e) => {
-                        error = e;
+                        error = Some(e);
                     }
                 }
             }
 
-            if !any_read {
-                Err(error)
-            } else {
-                #[cfg(feature = "virtual-input")]
-                self.virtual_keyboard.iter_over(|iter| {
-                    for (key, value) in iter {
-                        analog
-                            .entry(*key)
-                            .and_modify(|v| *v = v.max(*value))
-                            .or_insert(*value);
-                    }
-                });
-
-                Ok(analog)
+            if let Some(err) = error
+                && !any_read
+            {
+                return Err(ReadError::Device(err));
             }
+
+            #[cfg(feature = "virtual-input")]
+            self.virtual_keyboard.iter_over(|iter| {
+                for (key, value) in iter {
+                    analog
+                        .entry(*key)
+                        .and_modify(|v| *v = v.max(*value))
+                        .or_insert(*value);
+                }
+            });
+
+            Ok(analog)
         } else
         //If the device id is not 0, we try and find a connected device with that ID and read from it
         {
@@ -880,11 +871,11 @@ impl Plugin for WootingPlugin {
 
     fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices);
+            return Err(ReadError::Device(DeviceError::zero_devices()));
         }
 
         // If the Device ID is 0 we want to go through all the connected devices
@@ -902,7 +893,7 @@ impl Plugin for WootingPlugin {
                         any_read = true;
                     }
                     Err(e) => {
-                        error = e;
+                        error = Some(e);
                     }
                 }
             }
@@ -1057,9 +1048,9 @@ impl Plugin for WootingPlugin {
         }
     }
 
-    fn device_info(&mut self) -> WootingResult<Vec<DeviceInfo>> {
+    fn device_info(&mut self) -> Result<Vec<DeviceInfo>, ReadError> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
 
         let mut devices = vec![];

--- a/wooting-analog-sdk/src/plugin.rs
+++ b/wooting-analog-sdk/src/plugin.rs
@@ -18,8 +18,7 @@ use crate::err::{DeviceError, PluginError, ReadError};
 use crate::virtual_input::VirtualKeyboard;
 use crate::{
     AnalogData, AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceType, Key, KeyCode,
-    KeyMetadata, KeyNamespace, KeyPosition, KeyState, PhysicalKey, SDKResult, ValueMetadata,
-    WootingAnalogResult,
+    KeyMetadata, KeyNamespace, KeyPosition, KeyState, PhysicalKey, ValueMetadata,
 };
 
 #[cfg(target_os = "macos")]
@@ -61,13 +60,17 @@ pub trait Plugin {
     /// If `device` is 0 then no specific device is specified and the value should be read from all devices and combined
     fn read_analog(&mut self, code: u16, device_id: DeviceID) -> Result<f32, ReadError>;
 
-    fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue>;
+    fn read_keycode(
+        &mut self,
+        code: KeyCode,
+        device_id: DeviceID,
+    ) -> Result<AnalogValue, ReadError>;
 
     fn read_position(
         &mut self,
         position: KeyPosition,
         device_id: DeviceID,
-    ) -> SDKResult<PhysicalKey>;
+    ) -> Result<PhysicalKey, ReadError>;
 
     /// Function called to get the full analog read buffer for a particular device with ID `device`. `max_length` is the maximum amount
     /// of keys that can be accepted, any more beyond this will be ignored by the SDK.
@@ -78,19 +81,17 @@ pub trait Plugin {
         device: DeviceID,
     ) -> Result<HashMap<c_ushort, c_float>, ReadError>;
 
-    fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData>;
-
     fn read_keycodes(
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyCode, AnalogValue>>;
+    ) -> Result<HashMap<KeyCode, AnalogValue>, ReadError>;
 
     fn read_positions(
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyPosition, PhysicalKey>>;
+    ) -> Result<HashMap<KeyPosition, PhysicalKey>, ReadError>;
 }
 
 const ANALOG_BUFFER_SIZE_V1: usize = 48;
@@ -176,8 +177,8 @@ trait DeviceImplementation: DynClone + Send {
         &self,
         _device: &HidDevice,
         _max_length: usize,
-    ) -> SDKResult<Option<Vec<Key>>> {
-        SDKResult(Ok(None))
+    ) -> Result<Option<Vec<Key>>, DeviceError> {
+        Ok(None)
     }
 
     /// Get the unique device ID from the given `device_info`
@@ -259,18 +260,15 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
         &self,
         device: &HidDevice,
         max_length: usize,
-    ) -> SDKResult<Option<HashMap<c_ushort, c_float>>> {
-        SDKResult(
-            match self.get_analog_buffer_with_ctx(device, max_length).0 {
-                Ok(data) => match data {
-                    Some(data) => Ok(Some(
-                        data.iter()
-                            .map(|k| (k.code.as_u16(), k.value.as_f32()))
-                            .collect::<HashMap<c_ushort, c_float>>(),
-                    )),
-                    None => Ok(None),
-                },
-                Err(e) => Err(e),
+    ) -> Result<Option<HashMap<c_ushort, c_float>>, DeviceError> {
+        match self.get_analog_buffer_with_ctx(device, max_length) {
+            Ok(data) => match data {
+                Some(data) => Ok(Some(
+                    data.iter()
+                        .map(|k| (k.code.as_u16(), k.value.as_f32()))
+                        .collect::<HashMap<c_ushort, c_float>>(),
+                )),
+                None => Ok(None),
             },
             Err(e) => Err(e),
         }
@@ -280,7 +278,7 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
         &self,
         device: &HidDevice,
         max_length: usize,
-    ) -> SDKResult<Option<Vec<Key>>> {
+    ) -> Result<Option<Vec<Key>>, DeviceError> {
         let mut buffer: [u8; ANALOG_BUFFER_SIZE_V2] = [0; ANALOG_BUFFER_SIZE_V2];
         let res = device.read_timeout(&mut buffer, 50);
 
@@ -329,7 +327,7 @@ impl DeviceImplementation for WootingAnalogProtocolV2 {
                         ),
                     }
                 })
-                .filter(|(k, v)| k != &KeyCode::default() && v != &AnalogValue::default())
+                .filter(|k| k.value.inner > 0.0)
                 .collect(),
         ))
     }
@@ -447,19 +445,17 @@ impl Device {
         )
     }
 
-    fn read_keycode(&mut self, code: KeyCode) -> SDKResult<AnalogValue> {
+    fn read_keycode(&mut self, code: KeyCode) -> AnalogValue {
         let buffer_guard = self.buffer.lock().unwrap();
 
-        let value = buffer_guard
+        buffer_guard
             .iter()
             .find(|k| k.code == code)
             .map(|k| k.value)
-            .unwrap_or_default();
-
-        SDKResult(Ok(value))
+            .unwrap_or_default()
     }
 
-    fn read_position(&mut self, position: KeyPosition) -> SDKResult<PhysicalKey> {
+    fn read_position(&mut self, position: KeyPosition) -> PhysicalKey {
         let buffer_guard = self.buffer.lock().unwrap();
 
         let mut physical_key = PhysicalKey::new(position);
@@ -476,10 +472,10 @@ impl Device {
             }
         }
 
-        SDKResult(Ok(physical_key))
+        physical_key
     }
 
-    fn read_full_with_ctx(&mut self) -> SDKResult<Vec<Key>> {
+    fn read_full_with_ctx(&mut self) -> Result<Vec<Key>, DeviceError> {
         let mut buffer = self.buffer.lock().unwrap().clone();
         let new_pressed_keys = buffer.clone();
 
@@ -714,14 +710,16 @@ impl Plugin for WootingPlugin {
         info!("{} unloaded", PLUGIN_NAME);
     }
 
-    fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32> {
-        match self.read_keycode(KeyCode::from(code), device_id).0 {
-            Ok(v) => v.inner.into(),
-            Err(e) => Err(e).into(),
-        }
+    fn read_analog(&mut self, code: u16, device_id: DeviceID) -> Result<f32, ReadError> {
+        self.read_keycode(KeyCode::from(code), device_id)
+            .map(|v| v.inner)
     }
 
-    fn read_keycode(&mut self, code: KeyCode, device_id: DeviceID) -> SDKResult<AnalogValue> {
+    fn read_keycode(
+        &mut self,
+        code: KeyCode,
+        device_id: DeviceID,
+    ) -> Result<AnalogValue, ReadError> {
         if !self.initialised.load(Ordering::Relaxed) {
             return Err(ReadError::Uninitialized);
         }
@@ -732,24 +730,16 @@ impl Plugin for WootingPlugin {
 
         if device_id == 0 {
             let mut analog = AnalogValue::from(-1.0);
-            let mut error = WootingAnalogResult::Ok;
 
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_keycode(code).into() {
-                    Ok(value) => analog = analog.max(value),
-                    Err(e) => error = e,
-                }
+                analog = analog.max(device.read_keycode(code));
             }
 
-            if analog < 0.0 {
-                Err(error).into()
-            } else {
-                Ok(analog)
-            }
+            Ok(analog)
         } else {
             match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => device.read_keycode(code),
-                None => Err(WootingAnalogResult::NoDevices).into(),
+                Some(device) => Ok(device.read_keycode(code)),
+                None => Err(ReadError::Device(DeviceError::zero_devices())),
             }
         }
     }
@@ -758,39 +748,31 @@ impl Plugin for WootingPlugin {
         &mut self,
         position: KeyPosition,
         device_id: DeviceID,
-    ) -> SDKResult<PhysicalKey> {
+    ) -> Result<PhysicalKey, ReadError> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(ReadError::Uninitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices).into();
+            return Err(ReadError::Device(DeviceError::zero_devices()));
         }
 
         if device_id == 0 {
             let mut result = PhysicalKey::new(position);
-            let mut error = WootingAnalogResult::Ok;
 
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_position(position).into() {
-                    Ok(pk) => {
-                        for i in 0..pk.state_count {
-                            result.push_state(pk.states[i as usize]);
-                        }
-                    }
-                    Err(e) => error = e,
+                let pk = device.read_position(position);
+
+                for i in 0..pk.state_count {
+                    result.push_state(pk.states[i as usize]);
                 }
             }
 
-            if result.state_count == 0 {
-                Err(error).into()
-            } else {
-                SDKResult(Ok(result))
-            }
+            Ok(result)
         } else {
             match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => device.read_position(position),
-                None => Err(WootingAnalogResult::NoDevices).into(),
+                Some(device) => Ok(device.read_position(position)),
+                None => Err(ReadError::Device(DeviceError::zero_devices())),
             }
         }
     }
@@ -856,20 +838,25 @@ impl Plugin for WootingPlugin {
         //If the device id is not 0, we try and find a connected device with that ID and read from it
         {
             match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => match device.read_full_with_ctx().into() {
-                    Ok(val) => Ok(val
-                        .iter()
-                        .map(|k| (k.code.as_u16(), k.value.as_f32()))
-                        .collect())
-                    .into(),
-                    Err(e) => Err(e).into(),
-                },
-                None => Err(WootingAnalogResult::NoDevices),
+                Some(device) => device
+                    .read_full_with_ctx()
+                    .map(|values| {
+                        values
+                            .iter()
+                            .map(|k| (k.code.as_u16(), k.value.as_f32()))
+                            .collect()
+                    })
+                    .map_err(ReadError::Device),
+                None => Err(ReadError::Device(DeviceError::zero_devices())),
             }
         }
     }
 
-    fn read_full_buffer_with_ctx(&mut self, device_id: DeviceID) -> SDKResult<AnalogData> {
+    fn read_keycodes(
+        &mut self,
+        max_length: usize,
+        device_id: DeviceID,
+    ) -> Result<HashMap<KeyCode, AnalogValue>, ReadError> {
         if !self.initialised.load(Ordering::Relaxed) {
             return Err(ReadError::Uninitialized);
         }
@@ -883,10 +870,10 @@ impl Plugin for WootingPlugin {
         if device_id == 0 {
             let mut combined = AnalogData::new();
             let mut any_read = false;
-            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+            let mut error = None;
 
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_full_with_ctx().into() {
+                match device.read_full_with_ctx() {
                     Ok(keys) => {
                         let device_data = AnalogData::from(keys);
                         combined.merge(device_data);
@@ -898,91 +885,32 @@ impl Plugin for WootingPlugin {
                 }
             }
 
-            if !any_read {
-                Err(error)
-            } else {
-                // TODO: convert virtual keyboard to use KeyCode and AnalogValue
-                // #[cfg(feature = "virtual-input")]
-                // self.virtual_keyboard.iter_over(|iter| {
-                //     for (key, value) in iter {
-                //         analog
-                //             .entry(*key)
-                //             .and_modify(|v| *v = v.max(*value))
-                //             .or_insert(*value);
-                //     }
-                // });
-
-                Ok(combined).into()
+            if let Some(err) = error
+                && !any_read
+            {
+                return Err(ReadError::Device(err));
             }
+
+            // TODO: convert virtual keyboard to use KeyCode and AnalogValue
+            // #[cfg(feature = "virtual-input")]
+            // self.virtual_keyboard.iter_over(|iter| {
+            //     for (key, value) in iter {
+            //         analog
+            //             .entry(*key)
+            //             .and_modify(|v| *v = v.max(*value))
+            //             .or_insert(*value);
+            //     }
+            // });
+
+            Ok(combined.keycode_based)
         } else {
             // If the device id is not 0, we try and find a connected device with that ID and read from it
             match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => match device.read_full_with_ctx().into() {
-                    Ok(keys) => Ok(AnalogData::from(keys)).into(),
-                    Err(e) => Err(e).into(),
-                },
-                None => Err(WootingAnalogResult::NoDevices).into(),
-            }
-        }
-    }
-
-    fn read_keycodes(
-        &mut self,
-        max_length: usize,
-        device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
-        if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized).into();
-        }
-
-        if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices).into();
-        }
-
-        // If the Device ID is 0 we want to go through all the connected devices
-        // and combine the analog values
-        if device_id == 0 {
-            let mut combined = AnalogData::new();
-            let mut any_read = false;
-            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
-
-            for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_full_with_ctx().into() {
-                    Ok(keys) => {
-                        let device_data = AnalogData::from(keys);
-                        combined.merge(device_data);
-                        any_read = true;
-                    }
-                    Err(e) => {
-                        error = e;
-                    }
-                }
-            }
-
-            if !any_read {
-                Err(error).into()
-            } else {
-                // TODO: convert virtual keyboard to use KeyCode and AnalogValue
-                // #[cfg(feature = "virtual-input")]
-                // self.virtual_keyboard.iter_over(|iter| {
-                //     for (key, value) in iter {
-                //         analog
-                //             .entry(*key)
-                //             .and_modify(|v| *v = v.max(*value))
-                //             .or_insert(*value);
-                //     }
-                // });
-
-                Ok(combined.keycode_based).into()
-            }
-        } else {
-            // If the device id is not 0, we try and find a connected device with that ID and read from it
-            match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => match device.read_full_with_ctx().into() {
-                    Ok(keys) => Ok(AnalogData::from(keys).keycode_based).into(),
-                    Err(e) => Err(e).into(),
-                },
-                None => Err(WootingAnalogResult::NoDevices).into(),
+                Some(device) => device
+                    .read_full_with_ctx()
+                    .map(|keys| AnalogData::from(keys).keycode_based)
+                    .map_err(ReadError::Device),
+                None => Err(ReadError::Device(DeviceError::zero_devices())),
             }
         }
     }
@@ -991,13 +919,13 @@ impl Plugin for WootingPlugin {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyPosition, PhysicalKey>> {
+    ) -> Result<HashMap<KeyPosition, PhysicalKey>, ReadError> {
         if !self.initialised.load(Ordering::Relaxed) {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(ReadError::Uninitialized);
         }
 
         if self.devices.lock().unwrap().is_empty() {
-            return Err(WootingAnalogResult::NoDevices).into();
+            return Err(ReadError::Device(DeviceError::zero_devices()));
         }
 
         // If the Device ID is 0 we want to go through all the connected devices
@@ -1005,45 +933,47 @@ impl Plugin for WootingPlugin {
         if device_id == 0 {
             let mut combined = AnalogData::new();
             let mut any_read = false;
-            let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+            let mut error = None;
 
             for (_id, device) in self.devices.lock().unwrap().iter_mut() {
-                match device.read_full_with_ctx().into() {
+                match device.read_full_with_ctx() {
                     Ok(keys) => {
                         let device_data = AnalogData::from(keys);
                         combined.merge(device_data);
                         any_read = true;
                     }
                     Err(e) => {
-                        error = e;
+                        error = Some(e);
                     }
                 }
             }
 
-            if !any_read {
-                Err(error).into()
-            } else {
-                // TODO: convert virtual keyboard to use KeyCode and AnalogValue
-                // #[cfg(feature = "virtual-input")]
-                // self.virtual_keyboard.iter_over(|iter| {
-                //     for (key, value) in iter {
-                //         analog
-                //             .entry(*key)
-                //             .and_modify(|v| *v = v.max(*value))
-                //             .or_insert(*value);
-                //     }
-                // });
-
-                Ok(combined.position_based).into()
+            if let Some(err) = error
+                && !any_read
+            {
+                return Err(ReadError::Device(err));
             }
+
+            // TODO: convert virtual keyboard to use KeyCode and AnalogValue
+            // #[cfg(feature = "virtual-input")]
+            // self.virtual_keyboard.iter_over(|iter| {
+            //     for (key, value) in iter {
+            //         analog
+            //             .entry(*key)
+            //             .and_modify(|v| *v = v.max(*value))
+            //             .or_insert(*value);
+            //     }
+            // });
+
+            Ok(combined.position_based)
         } else {
             // If the device id is not 0, we try and find a connected device with that ID and read from it
             match self.devices.lock().unwrap().get_mut(&device_id) {
-                Some(device) => match device.read_full_with_ctx().into() {
-                    Ok(keys) => Ok(AnalogData::from(keys).position_based).into(),
-                    Err(e) => Err(e).into(),
-                },
-                None => Err(WootingAnalogResult::NoDevices),
+                Some(device) => device
+                    .read_full_with_ctx()
+                    .map(|keys| AnalogData::from(keys).position_based)
+                    .map_err(ReadError::Device),
+                None => Err(ReadError::Device(DeviceError::zero_devices())),
             }
         }
     }

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -25,15 +25,15 @@ macro_rules! lib_wrap {
                 fn $fn_names(&mut self, $($fn_arg_names: $fn_arg_tys),*) $(-> $fn_ret_tys)* {
                     unsafe {
                         type FnPtr = unsafe fn($($fn_arg_tys),*) $(-> $fn_ret_tys)*;
-                        //TODO: Retain the obtained function pointer between calls
-                        let func :  Option<Symbol<FnPtr>>  = self.lib.get(stringify!($fn_names).as_bytes()).map_err(|e| {
-                                    error!("{}", e);
-                                }).ok();
-                        match func {
-                            Some(f) => f($($fn_arg_names),*).into(),
-                            _ => Default::default()
 
-                        }
+                        //TODO: Retain the obtained function pointer between calls
+                        self.lib.get(stringify!($fn_names)
+                            .as_bytes())
+                            .inspect_err(|e| {
+                                error!("{}", e);
+                            })
+                            .map(|f: Symbol<FnPtr>| f($($fn_arg_names),*))
+                            .unwrap_or_default()
                     }
                 }
             //}
@@ -53,17 +53,17 @@ macro_rules! lib_wrap_option {
             //lib_wrap! {
             //    @as_item
                 #[unsafe(no_mangle)]
-                fn $fn_names(&mut self, $($fn_arg_names: $fn_arg_tys),*) $(-> WootingResult<$fn_ret_tys>)* {
+                fn $fn_names(&mut self, $($fn_arg_names: $fn_arg_tys),*) $(-> Result<$fn_ret_tys, WootingAnalogResult>)* {
                     unsafe {
                         type FnPtr = unsafe fn($($fn_arg_tys),*) $(-> $fn_ret_tys)*;
-                        let func :Option<Symbol<FnPtr>>  = self.lib.get(stringify!($fn_names).as_bytes()).map_err(|e| {
-                                    error!("{}", e);
-                                }).ok();
-                        match func {
-                            Some(f) => Ok(f($($fn_arg_names),*)),
-                            _ => Err(WootingAnalogResult::FunctionNotFound)
 
-                        }
+                        self.lib.get(stringify!($fn_names)
+                            .as_bytes())
+                            .inspect_err(|e| {
+                                error!("{}", e);
+                            })
+                            .map(|f: Symbol<FnPtr>| f($($fn_arg_names),*))
+                            .map_err(|_| WootingAnalogResult::FunctionNotFound)
                     }
                 }
             //}
@@ -80,7 +80,7 @@ pub struct CPlugin {
 }
 
 impl CPlugin {
-    pub fn new(lib: Library) -> WootingResult<CPlugin> {
+    pub fn new(lib: Library) -> Result<CPlugin, PluginError> {
         unsafe {
             if let Ok(ver) = lib.get::<*mut u32>(b"ANALOG_SDK_PLUGIN_ABI_VERSION") {
                 let v = **ver;
@@ -90,7 +90,10 @@ impl CPlugin {
                         "CPlugin ABI version does not match! Given: {}, Expected: {}",
                         v, CPLUGIN_ABI_VERSION
                     );
-                    return Err(WootingAnalogResult::IncompatibleVersion);
+                    return Err(PluginError::VersionMismatch {
+                        version: v,
+                        expected: CPLUGIN_ABI_VERSION,
+                    });
                 }
             }
         }
@@ -142,22 +145,26 @@ extern "C" fn call_closure(
 }
 
 impl Plugin for CPlugin {
-    fn name(&mut self) -> WootingResult<&'static str> {
-        self.name().map(|s| s.as_str())
+    fn name(&mut self) -> Result<&'static str, PluginError> {
+        self.name()
+            .map(|s| s.as_str())
+            .map_err(|_| PluginError::FunctionUnavailable("name"))
     }
 
     fn initialise(
         &mut self,
         callback: Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
-    ) -> WootingResult<u32> {
+    ) -> Result<u32, ReadError> {
         let data = Box::into_raw(Box::new(callback));
         self.cb_data_ptr = Some(data);
         self.initialise(data as *const _, call_closure)
             .map(|res| res as u32)
+            .map_err(|_| ReadError::Plugin(PluginError::FunctionUnavailable("initialise")))
     }
 
-    fn read_analog(&mut self, code: u16, device: DeviceID) -> WootingResult<f32> {
+    fn read_analog(&mut self, code: u16, device: DeviceID) -> Result<f32, ReadError> {
         self.read_analog(code, device)
+            .map_err(|_| ReadError::Plugin(PluginError::FunctionUnavailable("read_analog")))
     }
 
     fn read_keycode(
@@ -184,18 +191,22 @@ impl Plugin for CPlugin {
         &mut self,
         max_length: usize,
         device: DeviceID,
-    ) -> WootingResult<HashMap<c_ushort, c_float>> {
+    ) -> Result<HashMap<c_ushort, c_float>, ReadError> {
         let mut code_buffer: Vec<c_ushort> = Vec::with_capacity(max_length);
         let mut analog_buffer: Vec<c_float> = Vec::with_capacity(max_length);
         code_buffer.resize(max_length, 0);
         analog_buffer.resize(max_length, 0.0);
         let count: usize = {
-            let write_count = self.read_full_buffer(
-                code_buffer.as_ptr(),
-                analog_buffer.as_ptr(),
-                max_length as c_uint,
-                device,
-            )?;
+            let write_count = self
+                .read_full_buffer(
+                    code_buffer.as_ptr(),
+                    analog_buffer.as_ptr(),
+                    max_length as c_uint,
+                    device,
+                )
+                .map_err(|_| {
+                    ReadError::Plugin(PluginError::FunctionUnavailable("read_full_buffer"))
+                })?;
             max_length.min(write_count as usize)
         };
 
@@ -210,10 +221,12 @@ impl Plugin for CPlugin {
     fn read_full_buffer_with_ctx(&mut self, _device: DeviceID) -> SDKResult<AnalogData> {
         // TODO: for now let's assume c plugins can never supply this data
         // can be possible if we include it as an optional function that they can implement
-        Err(WootingAnalogResult::FunctionNotFound)
+        Err(ReadError::Plugin(PluginError::FunctionUnavailable(
+            "read_full_buffer_with_ctx",
+        )))
     }
 
-    fn device_info(&mut self) -> WootingResult<Vec<DeviceInfo>> {
+    fn device_info(&mut self) -> Result<Vec<DeviceInfo>, ReadError> {
         let mut device_infos: Vec<*const DeviceInfo_FFI> = vec![std::ptr::null_mut(); 10];
 
         match self
@@ -228,7 +241,9 @@ impl Plugin for CPlugin {
                     .collect();
                 Ok(devices)
             },
-            Err(e) => Err(e),
+            Err(_) => Err(ReadError::Plugin(PluginError::FunctionUnavailable(
+                "device_info",
+            ))),
         }
     }
 

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -6,8 +6,9 @@ use std::collections::HashMap;
 use std::os::raw::{c_float, c_int, c_uint, c_ushort, c_void};
 
 use crate::{
-    AnalogData, AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, Plugin,
-    SDKResult, WootingAnalogResult,
+    AnalogValue, DeviceEventType, DeviceID, DeviceInfo, DeviceInfo_FFI, KeyCode, KeyPosition,
+    PhysicalKey, Plugin,
+    err::{PluginError, ReadError, WootingAnalogResult},
 };
 
 macro_rules! lib_wrap {
@@ -169,22 +170,22 @@ impl Plugin for CPlugin {
 
     fn read_keycode(
         &mut self,
-        _code: crate::KeyCode,
+        _code: KeyCode,
         _device_id: DeviceID,
-    ) -> SDKResult<AnalogValue> {
+    ) -> Result<AnalogValue, ReadError> {
         // TODO: for now let's assume c plugins can not yet supply this data
-        // can easily be included via an optional fn in plugin.h 
-        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
+        // can easily be included via an optional fn in plugin.h
+        Err(ReadError::function_unavailable("read_keycode"))
     }
 
     fn read_position(
         &mut self,
-        _position: crate::KeyPosition,
+        _position: KeyPosition,
         _device_id: DeviceID,
-    ) -> SDKResult<crate::PhysicalKey> {
+    ) -> Result<PhysicalKey, ReadError> {
         // TODO: for now let's assume c plugins can not yet supply this data
-        // can easily be included via an optional fn in plugin.h 
-        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
+        // can easily be included via an optional fn in plugin.h
+        Err(ReadError::function_unavailable("read_position"))
     }
 
     fn read_full_buffer(
@@ -214,12 +215,6 @@ impl Plugin for CPlugin {
         }
 
         Ok(analog_data)
-    }
-
-    fn read_full_buffer_with_ctx(&mut self, _device: DeviceID) -> SDKResult<AnalogData> {
-        // TODO: for now let's assume c plugins can never supply this data
-        // can be possible if we include it as an optional function that they can implement
-        Err(ReadError::function_unavailable("read_full_buffer_with_ctx"))
     }
 
     fn device_info(&mut self) -> Result<Vec<DeviceInfo>, ReadError> {
@@ -261,15 +256,15 @@ impl Plugin for CPlugin {
         &mut self,
         _max_length: usize,
         _device_id: DeviceID,
-    ) -> SDKResult<HashMap<crate::KeyCode, AnalogValue>> {
-        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
+    ) -> Result<HashMap<KeyCode, AnalogValue>, ReadError> {
+        Err(ReadError::function_unavailable("read_keycodes"))
     }
 
     fn read_positions(
         &mut self,
         _max_length: usize,
         _device_id: DeviceID,
-    ) -> SDKResult<HashMap<crate::KeyPosition, crate::PhysicalKey>> {
-        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
+    ) -> Result<HashMap<KeyPosition, PhysicalKey>, ReadError> {
+        Err(ReadError::function_unavailable("read_positions"))
     }
 }

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -53,15 +53,15 @@ macro_rules! lib_wrap_option {
             //lib_wrap! {
             //    @as_item
                 #[unsafe(no_mangle)]
-                fn $fn_names(&mut self, $($fn_arg_names: $fn_arg_tys),*) $(-> SDKResult<$fn_ret_tys>)* {
+                fn $fn_names(&mut self, $($fn_arg_names: $fn_arg_tys),*) $(-> WootingResult<$fn_ret_tys>)* {
                     unsafe {
                         type FnPtr = unsafe fn($($fn_arg_tys),*) $(-> $fn_ret_tys)*;
                         let func :Option<Symbol<FnPtr>>  = self.lib.get(stringify!($fn_names).as_bytes()).map_err(|e| {
                                     error!("{}", e);
                                 }).ok();
                         match func {
-                            Some(f) => f($($fn_arg_names),*).into(),
-                            _ => Err(WootingAnalogResult::FunctionNotFound).into()
+                            Some(f) => Ok(f($($fn_arg_names),*)),
+                            _ => Err(WootingAnalogResult::FunctionNotFound)
 
                         }
                     }
@@ -80,9 +80,9 @@ pub struct CPlugin {
 }
 
 impl CPlugin {
-    pub fn new(lib: Library) -> SDKResult<CPlugin> {
+    pub fn new(lib: Library) -> WootingResult<CPlugin> {
         unsafe {
-            if let Some(ver) = lib.get::<*mut u32>(b"ANALOG_SDK_PLUGIN_ABI_VERSION").ok() {
+            if let Ok(ver) = lib.get::<*mut u32>(b"ANALOG_SDK_PLUGIN_ABI_VERSION") {
                 let v = **ver;
                 info!("Got cplugin abi: {:?}", v);
                 if v != CPLUGIN_ABI_VERSION {
@@ -90,7 +90,7 @@ impl CPlugin {
                         "CPlugin ABI version does not match! Given: {}, Expected: {}",
                         v, CPLUGIN_ABI_VERSION
                     );
-                    return Err(WootingAnalogResult::IncompatibleVersion).into();
+                    return Err(WootingAnalogResult::IncompatibleVersion);
                 }
             }
         }
@@ -99,7 +99,6 @@ impl CPlugin {
             lib,
             cb_data_ptr: None, //funcs: HashMap::new()
         })
-        .into()
     }
 
     lib_wrap_option! {
@@ -143,23 +142,21 @@ extern "C" fn call_closure(
 }
 
 impl Plugin for CPlugin {
-    fn name(&mut self) -> SDKResult<&'static str> {
-        self.name().0.map(|s| s.as_str()).into()
+    fn name(&mut self) -> WootingResult<&'static str> {
+        self.name().map(|s| s.as_str())
     }
 
     fn initialise(
         &mut self,
         callback: Box<dyn Fn(DeviceEventType, &DeviceInfo) + Send>,
-    ) -> SDKResult<u32> {
+    ) -> WootingResult<u32> {
         let data = Box::into_raw(Box::new(callback));
         self.cb_data_ptr = Some(data);
         self.initialise(data as *const _, call_closure)
-            .0
             .map(|res| res as u32)
-            .into()
     }
 
-    fn read_analog(&mut self, code: u16, device: DeviceID) -> SDKResult<f32> {
+    fn read_analog(&mut self, code: u16, device: DeviceID) -> WootingResult<f32> {
         self.read_analog(code, device)
     }
 
@@ -187,26 +184,19 @@ impl Plugin for CPlugin {
         &mut self,
         max_length: usize,
         device: DeviceID,
-    ) -> SDKResult<HashMap<c_ushort, c_float>> {
+    ) -> WootingResult<HashMap<c_ushort, c_float>> {
         let mut code_buffer: Vec<c_ushort> = Vec::with_capacity(max_length);
         let mut analog_buffer: Vec<c_float> = Vec::with_capacity(max_length);
         code_buffer.resize(max_length, 0);
         analog_buffer.resize(max_length, 0.0);
         let count: usize = {
-            let ret = self
-                .read_full_buffer(
-                    code_buffer.as_ptr(),
-                    analog_buffer.as_ptr(),
-                    max_length as c_uint,
-                    device,
-                )
-                .0;
-            if let Err(e) = ret {
-                //debug!("Error got: {:?}",e);
-                return Err(e).into();
-            }
-            let ret = ret.unwrap();
-            max_length.min(ret as usize)
+            let write_count = self.read_full_buffer(
+                code_buffer.as_ptr(),
+                analog_buffer.as_ptr(),
+                max_length as c_uint,
+                device,
+            )?;
+            max_length.min(write_count as usize)
         };
 
         let mut analog_data: HashMap<c_ushort, c_float> = HashMap::with_capacity(count);
@@ -214,21 +204,20 @@ impl Plugin for CPlugin {
             analog_data.insert(code_buffer[i], analog_buffer[i]);
         }
 
-        Ok(analog_data).into()
+        Ok(analog_data)
     }
 
     fn read_full_buffer_with_ctx(&mut self, _device: DeviceID) -> SDKResult<AnalogData> {
         // TODO: for now let's assume c plugins can never supply this data
         // can be possible if we include it as an optional function that they can implement
-        SDKResult(Err(WootingAnalogResult::FunctionNotFound))
+        Err(WootingAnalogResult::FunctionNotFound)
     }
 
-    fn device_info(&mut self) -> SDKResult<Vec<DeviceInfo>> {
+    fn device_info(&mut self) -> WootingResult<Vec<DeviceInfo>> {
         let mut device_infos: Vec<*const DeviceInfo_FFI> = vec![std::ptr::null_mut(); 10];
 
         match self
             .device_info(device_infos.as_mut_ptr(), device_infos.len() as c_uint)
-            .0
             .map(|no| no as u32)
         {
             Ok(num) => unsafe {
@@ -237,9 +226,9 @@ impl Plugin for CPlugin {
                     .drain(..)
                     .map(|dev| dev.as_ref().unwrap().into_device_info())
                     .collect();
-                Ok(devices).into()
+                Ok(devices)
             },
-            Err(e) => Err(e).into(),
+            Err(e) => Err(e),
         }
     }
 

--- a/wooting-analog-sdk/src/plugin/c.rs
+++ b/wooting-analog-sdk/src/plugin/c.rs
@@ -159,12 +159,12 @@ impl Plugin for CPlugin {
         self.cb_data_ptr = Some(data);
         self.initialise(data as *const _, call_closure)
             .map(|res| res as u32)
-            .map_err(|_| ReadError::Plugin(PluginError::FunctionUnavailable("initialise")))
+            .map_err(|_| ReadError::function_unavailable("initialise"))
     }
 
     fn read_analog(&mut self, code: u16, device: DeviceID) -> Result<f32, ReadError> {
         self.read_analog(code, device)
-            .map_err(|_| ReadError::Plugin(PluginError::FunctionUnavailable("read_analog")))
+            .map_err(|_| ReadError::function_unavailable("read_analog"))
     }
 
     fn read_keycode(
@@ -204,9 +204,7 @@ impl Plugin for CPlugin {
                     max_length as c_uint,
                     device,
                 )
-                .map_err(|_| {
-                    ReadError::Plugin(PluginError::FunctionUnavailable("read_full_buffer"))
-                })?;
+                .map_err(|_| ReadError::function_unavailable("read_full_buffer"))?;
             max_length.min(write_count as usize)
         };
 
@@ -221,9 +219,7 @@ impl Plugin for CPlugin {
     fn read_full_buffer_with_ctx(&mut self, _device: DeviceID) -> SDKResult<AnalogData> {
         // TODO: for now let's assume c plugins can never supply this data
         // can be possible if we include it as an optional function that they can implement
-        Err(ReadError::Plugin(PluginError::FunctionUnavailable(
-            "read_full_buffer_with_ctx",
-        )))
+        Err(ReadError::function_unavailable("read_full_buffer_with_ctx"))
     }
 
     fn device_info(&mut self) -> Result<Vec<DeviceInfo>, ReadError> {
@@ -241,9 +237,7 @@ impl Plugin for CPlugin {
                     .collect();
                 Ok(devices)
             },
-            Err(_) => Err(ReadError::Plugin(PluginError::FunctionUnavailable(
-                "device_info",
-            ))),
+            Err(_) => Err(ReadError::function_unavailable("device_info")),
         }
     }
 

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -8,16 +8,13 @@ use crate::KeyPosition;
 use crate::KeycodeType;
 use crate::PhysicalKey;
 use crate::Plugin;
-use crate::err::WootingAnalogResult;
-use crate::err::WootingResult;
+use crate::err::PluginError;
+use crate::err::ReadError;
 use crate::keycode::*;
-use crate::plugin::ANALOG_SDK_PLUGIN_VERSION;
 use crate::plugin::DEFAULT_PLUGIN_DIR;
 use crate::plugin::WootingPlugin;
 use crate::plugin::c::CPlugin;
-use anyhow::bail;
-use anyhow::{Context, Error, Result};
-use libloading::{Library, Symbol};
+use libloading::Library;
 use log::debug;
 use log::trace;
 use log::{error, info, warn};
@@ -38,16 +35,6 @@ pub struct AnalogSDK {
     device_event_callback: Arc<Mutex<Option<Box<dyn Fn(DeviceEventType, DeviceInfo) + Send>>>>,
 }
 
-pub fn print_error(err: Error) -> Error {
-    error!("{:#}", err);
-    err
-}
-
-pub fn print_warn(err: Error) -> Error {
-    warn!("{:#}", err);
-    err
-}
-
 #[cfg(target_os = "macos")]
 static LIB_EXT: &str = "dylib";
 #[cfg(target_os = "linux")]
@@ -66,7 +53,7 @@ impl AnalogSDK {
         }
     }
 
-    pub fn initialise(&mut self) -> WootingResult<u32> {
+    pub fn initialise(&mut self) -> Result<u32, ReadError> {
         let dir = option_env!("WOOTING_ANALOG_SDK_PLUGINS_PATH").unwrap_or(DEFAULT_PLUGIN_DIR);
         self.initialise_with_plugin_path(dir, true)
     }
@@ -75,7 +62,7 @@ impl AnalogSDK {
         &mut self,
         plugin_dir: &str,
         nested: bool,
-    ) -> WootingResult<u32> {
+    ) -> Result<u32, ReadError> {
         if self.initialised {
             self.unload();
         }
@@ -168,19 +155,17 @@ impl AnalogSDK {
 
         self.initialised = plugins_initialised > 0;
         if !self.initialised {
-            Err(WootingAnalogResult::NoPlugins)
+            Err(ReadError::Plugin(PluginError::ZeroPlugins))
         } else {
             Ok(device_no)
         }
     }
 
-    fn load_plugins(&mut self, dir: &Path) -> Result<u32> {
+    fn load_plugins(&mut self, dir: &Path) -> Result<u32, PluginError> {
         if dir.is_dir() {
             let mut i: u32 = 0;
-            for entry in fs::read_dir(dir)
-                .with_context(|| format!("Unable to load dir \"{}\"", dir.display()))?
-            {
-                let path = entry.context("Err with entry")?.path();
+            for entry in fs::read_dir(dir)? {
+                let path = entry?.path();
 
                 if let Some(ext) = path.extension().and_then(OsStr::to_str) {
                     if ext == LIB_EXT {
@@ -188,8 +173,7 @@ impl AnalogSDK {
                         unsafe {
                             if self
                                 .load_plugin(&path)
-                                .context("Load Plugin failed")
-                                .map_err(print_error)
+                                .inspect_err(|e| error!("failed to load plugin: {e}"))
                                 .is_ok()
                             {
                                 i += 1;
@@ -201,122 +185,33 @@ impl AnalogSDK {
             return Ok(i);
         }
 
-        bail!("Path: {:?} is not a dir!", dir)
+        Err(PluginError::InvalidDirectory(dir.to_path_buf()))
     }
 
-    unsafe fn load_plugin(&mut self, filename: &Path) -> Result<()> {
-        if filename.is_dir() {
-            bail!("Path is directory!");
+    unsafe fn load_plugin(&mut self, path: &Path) -> Result<CPlugin, PluginError> {
+        if path.is_dir() {
+            return Err(PluginError::InvalidPlugin(path.to_path_buf()));
         }
 
-        type PluginCreate = unsafe extern "C" fn() -> *mut dyn Plugin;
-        type PluginVersion = unsafe extern "C" fn() -> &'static str;
+        let mut plugin = CPlugin::new(
+            unsafe { Library::new(path) }
+                .map_err(|e| PluginError::DynamicLibraryError { source: e })?,
+        )?;
 
-        let lib = Library::new(filename.as_os_str()).context("Unable to load the plugin")?;
+        println!("calling name of plugin");
+        plugin
+            .name()
+            .inspect(|name| println!("Loaded plugin: {:?}", name))?;
 
-        // We need to keep the library around otherwise our plugin's vtable will
-        // point to garbage. We do this little dance to make sure the library
-        // doesn't end up getting moved.
-        self.loaded_libraries.push(lib);
-
-        let lib = self.loaded_libraries.last().unwrap();
-
-        let full_version: Option<Symbol<PluginVersion>> = lib.get(b"plugin_version").ok();
-        let mut got_ver = false;
-        if let Some(f_ver) = full_version {
-            got_ver = true;
-            let ver = f_ver();
-            debug!(
-                "Plugin got plugin-dev sem version: {}. SDK: {}",
-                ver, ANALOG_SDK_PLUGIN_VERSION
-            );
-
-            if let Some(major_ver) = ANALOG_SDK_PLUGIN_VERSION
-                .split('.')
-                .collect::<Vec<&str>>()
-                .first()
-            {
-                if let Some(plugin_major_ver) = ver.split('.').collect::<Vec<&str>>().first() {
-                    if major_ver.eq(plugin_major_ver) {
-                        info!("Plugin and SDK are compatible!");
-                    } else {
-                        bail!(
-                            "Plugin has major version {}, which is incompatible with the SDK's: {}",
-                            plugin_major_ver,
-                            ANALOG_SDK_PLUGIN_VERSION
-                        );
-                    }
-                } else {
-                    bail!(
-                        "Unable to get the Plugin's major version from SemVer {}",
-                        ver
-                    );
-                }
-            } else {
-                bail!(
-                    "Unable to get the SDK's Plugin major version from SemVer {}",
-                    ANALOG_SDK_PLUGIN_VERSION
-                );
-            }
-        } else {
-            warn!("Unable to determine the Plugin's SemVer!");
-        }
-
-        let constructor: Option<Symbol<PluginCreate>> = lib
-            .get(b"_plugin_create")
-            .context("Failed to find constructor (_plugin_create symbol)")
-            .map_err(print_warn)
-            .ok();
-
-        let mut plugin = match constructor {
-            Some(f) => {
-                if !got_ver {
-                    bail!("Unable to determine the Plugin's SemVer!");
-                }
-
-                debug!("We got it and we're trying");
-                Box::from_raw(f())
-            }
-            None => {
-                info!("Didn't find _plugin_create, assuming it's a C plugin");
-                let lib = self.loaded_libraries.pop().unwrap();
-                match CPlugin::new(lib) {
-                    Ok(cplugin) => Box::new(cplugin),
-                    Err(WootingAnalogResult::IncompatibleVersion) => {
-                        bail!(
-                            "Plugin is a C plugin which is incompatible with this version of the SDK"
-                        );
-                    }
-                    Err(_) => {
-                        bail!("Plugin isn't a valid C or Rust plugin");
-                    }
-                }
-            }
-        };
-        let name = plugin.name();
-        match name {
-            Ok(name) => {
-                info!("Loaded plugin: {:?}", name);
-                //plugin.on_plugin_load();
-                self.plugins.push(plugin);
-            }
-            Err(WootingAnalogResult::FunctionNotFound) => {
-                bail!("Plugin isn't a valid plugin, name function not found");
-            }
-            Err(e) => {
-                bail!("Plugin failed with unhandled error {:?}", e);
-            }
-        }
-
-        Ok(())
+        Ok(plugin)
     }
 
     pub fn set_device_event_cb(
         &mut self,
         cb: impl Fn(DeviceEventType, DeviceInfo) + 'static + Send,
-    ) -> WootingResult<()> {
+    ) -> Result<(), ReadError> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
         self.device_event_callback
             .lock()
@@ -326,21 +221,21 @@ impl AnalogSDK {
         Ok(())
     }
 
-    pub fn clear_device_event_cb(&mut self) -> WootingResult<()> {
+    pub fn clear_device_event_cb(&mut self) -> Result<(), ReadError> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
         self.device_event_callback.lock().unwrap().take();
 
         Ok(())
     }
 
-    pub fn get_device_info(&mut self) -> WootingResult<Vec<DeviceInfo>> {
+    pub fn get_device_info(&mut self) -> Result<Vec<DeviceInfo>, ReadError> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
         let mut devices: Vec<DeviceInfo> = vec![];
-        let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
+        let mut error = None;
         for p in self.plugins.iter_mut() {
             if !p.is_initialised() {
                 continue;
@@ -357,27 +252,30 @@ impl AnalogSDK {
                         p.name(),
                         e
                     );
-                    error = e;
+                    error = Some(e);
                 }
             }
         }
-        if devices.is_empty() && !error.is_ok() {
-            Err(error)
-        } else {
-            Ok(devices)
+
+        if let Some(err) = error
+            && devices.is_empty()
+        {
+            return Err(err);
         }
+
+        Ok(devices)
     }
 
-    pub fn read_analog(&mut self, code: u16, device_id: DeviceID) -> WootingResult<f32> {
+    pub fn read_analog(&mut self, code: u16, device_id: DeviceID) -> Result<f32, ReadError> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
 
         //Try and map the given keycode to HID
         let hid_code = code_to_hid(code, &self.keycode_mode);
         if let Some(hid_code) = hid_code {
             let mut value: f32 = -1.0;
-            let mut err = WootingAnalogResult::Ok;
+            let mut err = None;
 
             for p in self.plugins.iter_mut() {
                 match p.read_analog(hid_code, device_id) {
@@ -390,18 +288,23 @@ impl AnalogSDK {
                     }
                     Err(e) => {
                         //TODO: Improve collating of multiple errors
-                        err = e
+                        err = Some(e)
                     }
                 }
             }
 
-            if value < 0.0 {
+            if let Some(err) = err
+                && value < 0.0
+            {
                 return Err(err);
             }
 
             Ok(value)
         } else {
-            Err(WootingAnalogResult::NoMapping)
+            Err(ReadError::NoMapping {
+                keycode: code,
+                mode: self.keycode_mode.clone(),
+            })
         }
     }
 
@@ -409,14 +312,14 @@ impl AnalogSDK {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> WootingResult<HashMap<u16, f32>> {
+    ) -> Result<HashMap<u16, f32>, ReadError> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
 
         let mut analog_data: HashMap<u16, f32> = HashMap::with_capacity(max_length);
 
-        let mut err = WootingAnalogResult::Ok;
+        let mut err = None;
         let mut any_success = false;
         //Read from all and add up
         for p in self.plugins.iter_mut() {
@@ -450,7 +353,7 @@ impl AnalogSDK {
                 }
                 Err(e) => {
                     //TODO: Improve collating of multiple errors
-                    err = e
+                    err = Some(e)
                 }
             }
             //If we are looking for a specific device, just break out when we find one that returns good
@@ -458,7 +361,10 @@ impl AnalogSDK {
                 break;
             }
         }
-        if !any_success {
+
+        if let Some(err) = err
+            && !any_success
+        {
             return Err(err);
         }
 
@@ -467,7 +373,7 @@ impl AnalogSDK {
 
     pub(crate) fn read_keycode(&mut self, code: u16, device_id: DeviceID) -> SDKResult<AnalogValue> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized);
+            return Err(ReadError::Uninitialized);
         }
 
         let Some(hid_code) = crate::keycode::code_to_hid(code, &self.keycode_mode) else {

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -374,87 +374,114 @@ impl AnalogSDK {
         Ok(analog_data)
     }
 
-    pub(crate) fn read_keycode(&mut self, code: u16, device_id: DeviceID) -> SDKResult<AnalogValue> {
+    pub(crate) fn read_keycode(
+        &mut self,
+        code: u16,
+        device_id: DeviceID,
+    ) -> Result<AnalogValue, ReadError> {
         if !self.initialised {
             return Err(ReadError::Uninitialized);
         }
 
         let Some(hid_code) = crate::keycode::code_to_hid(code, &self.keycode_mode) else {
-            return Err(WootingAnalogResult::NoMapping).into();
+            return Err(ReadError::NoMapping {
+                keycode: code,
+                mode: self.keycode_mode.clone(),
+            });
         };
 
         let mut value = AnalogValue::from(-1.0);
-        let mut err = WootingAnalogResult::Ok;
+        let mut error = None;
 
         for p in self.plugins.iter_mut() {
-            match p.read_keycode(KeyCode::from(hid_code), device_id).into() {
+            match p.read_keycode(KeyCode::from(hid_code), device_id) {
                 Ok(x) => {
                     value = value.max(x);
                     if device_id != 0 {
                         break;
                     }
                 }
-                Err(e) => err = e,
+                Err(e) => error = Some(e),
             }
         }
 
-        if value < 0.0 {
-            return Err(err).into();
+        if let Some(err) = error
+            && value < 0.0
+        {
+            return Err(err);
         }
 
-        SDKResult(Ok(value))
+        Ok(value)
     }
 
     pub(crate) fn read_position(
         &mut self,
         position: KeyPosition,
         device_id: DeviceID,
-    ) -> SDKResult<PhysicalKey> {
+    ) -> Result<PhysicalKey, ReadError> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(ReadError::Uninitialized);
         }
 
-        let mut result = PhysicalKey::new(position);
-        let mut err = WootingAnalogResult::Ok;
+        let mut physical_key = PhysicalKey::new(position);
+        let mut error = None;
 
         for p in self.plugins.iter_mut() {
-            match p.read_position(position, device_id).into() {
+            match p.read_position(position, device_id) {
                 Ok(pk) => {
                     for i in 0..pk.state_count {
-                        result.push_state(pk.states[i as usize]);
+                        physical_key.push_state(pk.states[i as usize]);
                     }
                     if device_id != 0 {
                         break;
                     }
                 }
-                Err(e) => err = e,
+                Err(e) => error = Some(e),
             }
         }
 
-        if result.state_count == 0 {
-            return Err(err).into();
+        if let Some(err) = error
+            && physical_key.state_count == 0
+        {
+            return Err(err);
         }
 
-        SDKResult(Ok(result))
+        Ok(physical_key)
     }
 
-    pub(crate) fn inputs(&mut self, device_id: DeviceID) -> SDKResult<AnalogData> {
+    // TODO: hide hashmap impl detail behind opaque struct
+    // will probably be -> InputsPosition { .. }
+    // could even try Inputs<Position> ?
+    pub(crate) fn read_positions(
+        &mut self,
+        device_id: DeviceID,
+    ) -> Result<HashMap<KeyPosition, PhysicalKey>, ReadError> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(ReadError::Uninitialized);
         }
 
-        let mut combined = AnalogData::new();
-        let mut err = WootingAnalogResult::Ok;
+        let mut positions = HashMap::new();
+        let mut error = None;
         let mut any_success = false;
 
         for p in self.plugins.iter_mut() {
-            match p.read_full_buffer_with_ctx(device_id).into() {
+            match p.read_positions(0, device_id) {
                 Ok(plugin_data) => {
-                    combined.merge(plugin_data);
+                    for (_, physical_key) in plugin_data {
+                        positions
+                            .entry(physical_key.pos)
+                            .and_modify(|existing: &mut PhysicalKey| {
+                                if physical_key.max_value() > existing.max_value() {
+                                    *existing = physical_key;
+                                }
+                            })
+                            .or_insert(physical_key);
+                    }
+
                     any_success = true;
                 }
                 Err(e) => {
-                    err = e;
+                    error = Some(e);
                 }
             }
 
@@ -464,24 +491,13 @@ impl AnalogSDK {
             }
         }
 
-        if !any_success {
+        if let Some(err) = error
+            && !any_success
+        {
             return Err(err);
         }
 
-        Ok(combined).into()
-    }
-
-    // TODO: hide hashmap impl detail behind opaque struct
-    // will probably be -> InputsPosition { .. }
-    // could even try Inputs<Position> ?
-    pub(crate) fn read_positions(
-        &mut self,
-        device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyPosition, PhysicalKey>> {
-        self.inputs(device_id)
-            .0
-            .map(|data| data.position_based)
-            .into()
+        Ok(positions)
     }
 
     // TODO: hide hashmap impl detail behind opaque struct
@@ -490,11 +506,49 @@ impl AnalogSDK {
     pub(crate) fn read_keycodes(
         &mut self,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<KeyCode, AnalogValue>> {
-        self.inputs(device_id)
-            .0
-            .map(|data| data.keycode_based)
-            .into()
+    ) -> Result<HashMap<KeyCode, AnalogValue>, ReadError> {
+        if !self.initialised {
+            return Err(ReadError::Uninitialized);
+        }
+
+        let mut keycodes = HashMap::new();
+        let mut error = None;
+        let mut any_success = false;
+
+        for p in self.plugins.iter_mut() {
+            match p.read_keycodes(0, device_id) {
+                Ok(plugin_data) => {
+                    for (k, v) in plugin_data {
+                        keycodes
+                            .entry(k)
+                            .and_modify(|existing| {
+                                if &v > existing {
+                                    *existing = v;
+                                }
+                            })
+                            .or_insert(v);
+                    }
+
+                    any_success = true;
+                }
+                Err(e) => {
+                    error = Some(e);
+                }
+            }
+
+            // If looking for a specific device, break after first successful read
+            if device_id != 0 && any_success {
+                break;
+            }
+        }
+
+        if let Some(err) = error
+            && !any_success
+        {
+            return Err(err);
+        }
+
+        Ok(keycodes)
     }
 
     /// Unload all plugins and loaded plugin libraries, making sure to fire

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -188,7 +188,7 @@ impl AnalogSDK {
         Err(PluginError::InvalidDirectory(dir.to_path_buf()))
     }
 
-    unsafe fn load_plugin(&mut self, path: &Path) -> Result<CPlugin, PluginError> {
+    unsafe fn load_plugin(&mut self, path: &Path) -> Result<(), PluginError> {
         if path.is_dir() {
             return Err(PluginError::InvalidPlugin(path.to_path_buf()));
         }
@@ -203,7 +203,10 @@ impl AnalogSDK {
             .name()
             .inspect(|name| println!("Loaded plugin: {:?}", name))?;
 
-        Ok(plugin)
+        self.plugins.push(Box::new(plugin));
+
+        // Ok(plugin)
+        Ok(())
     }
 
     pub fn set_device_event_cb(

--- a/wooting-analog-sdk/src/sdk.rs
+++ b/wooting-analog-sdk/src/sdk.rs
@@ -8,8 +8,8 @@ use crate::KeyPosition;
 use crate::KeycodeType;
 use crate::PhysicalKey;
 use crate::Plugin;
-use crate::SDKResult;
-use crate::WootingAnalogResult;
+use crate::err::WootingAnalogResult;
+use crate::err::WootingResult;
 use crate::keycode::*;
 use crate::plugin::ANALOG_SDK_PLUGIN_VERSION;
 use crate::plugin::DEFAULT_PLUGIN_DIR;
@@ -66,7 +66,7 @@ impl AnalogSDK {
         }
     }
 
-    pub fn initialise(&mut self) -> SDKResult<u32> {
+    pub fn initialise(&mut self) -> WootingResult<u32> {
         let dir = option_env!("WOOTING_ANALOG_SDK_PLUGINS_PATH").unwrap_or(DEFAULT_PLUGIN_DIR);
         self.initialise_with_plugin_path(dir, true)
     }
@@ -75,7 +75,7 @@ impl AnalogSDK {
         &mut self,
         plugin_dir: &str,
         nested: bool,
-    ) -> SDKResult<u32> {
+    ) -> WootingResult<u32> {
         if self.initialised {
             self.unload();
         }
@@ -158,7 +158,7 @@ impl AnalogSDK {
                 },
             ));
             debug!("{:?}", ret);
-            if let Ok(num) = ret.0 {
+            if let Ok(num) = ret {
                 plugins_initialised += 1;
                 device_no += num;
             }
@@ -168,9 +168,9 @@ impl AnalogSDK {
 
         self.initialised = plugins_initialised > 0;
         if !self.initialised {
-            Err(WootingAnalogResult::NoPlugins).into()
+            Err(WootingAnalogResult::NoPlugins)
         } else {
-            Ok(device_no).into()
+            Ok(device_no)
         }
     }
 
@@ -280,7 +280,7 @@ impl AnalogSDK {
             None => {
                 info!("Didn't find _plugin_create, assuming it's a C plugin");
                 let lib = self.loaded_libraries.pop().unwrap();
-                match CPlugin::new(lib).0 {
+                match CPlugin::new(lib) {
                     Ok(cplugin) => Box::new(cplugin),
                     Err(WootingAnalogResult::IncompatibleVersion) => {
                         bail!(
@@ -294,7 +294,7 @@ impl AnalogSDK {
             }
         };
         let name = plugin.name();
-        match name.0 {
+        match name {
             Ok(name) => {
                 info!("Loaded plugin: {:?}", name);
                 //plugin.on_plugin_load();
@@ -314,30 +314,30 @@ impl AnalogSDK {
     pub fn set_device_event_cb(
         &mut self,
         cb: impl Fn(DeviceEventType, DeviceInfo) + 'static + Send,
-    ) -> SDKResult<()> {
+    ) -> WootingResult<()> {
         if !self.initialised {
-            return WootingAnalogResult::UnInitialized.into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
         self.device_event_callback
             .lock()
             .unwrap()
             .replace(Box::new(cb));
 
-        Ok(()).into()
+        Ok(())
     }
 
-    pub fn clear_device_event_cb(&mut self) -> SDKResult<()> {
+    pub fn clear_device_event_cb(&mut self) -> WootingResult<()> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
         self.device_event_callback.lock().unwrap().take();
 
-        Ok(()).into()
+        Ok(())
     }
 
-    pub fn get_device_info(&mut self) -> SDKResult<Vec<DeviceInfo>> {
+    pub fn get_device_info(&mut self) -> WootingResult<Vec<DeviceInfo>> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
         let mut devices: Vec<DeviceInfo> = vec![];
         let mut error: WootingAnalogResult = WootingAnalogResult::Ok;
@@ -347,7 +347,7 @@ impl AnalogSDK {
             }
 
             //Give a reference to the buffer at the point where there is free space
-            match p.device_info().0 {
+            match p.device_info() {
                 Ok(mut p_devices) => {
                     devices.append(&mut p_devices);
                 }
@@ -362,15 +362,15 @@ impl AnalogSDK {
             }
         }
         if devices.is_empty() && !error.is_ok() {
-            Err(error).into()
+            Err(error)
         } else {
-            Ok(devices).into()
+            Ok(devices)
         }
     }
 
-    pub fn read_analog(&mut self, code: u16, device_id: DeviceID) -> SDKResult<f32> {
+    pub fn read_analog(&mut self, code: u16, device_id: DeviceID) -> WootingResult<f32> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
 
         //Try and map the given keycode to HID
@@ -380,7 +380,7 @@ impl AnalogSDK {
             let mut err = WootingAnalogResult::Ok;
 
             for p in self.plugins.iter_mut() {
-                match p.read_analog(hid_code, device_id).into() {
+                match p.read_analog(hid_code, device_id) {
                     Ok(x) => {
                         value = value.max(x);
                         //If we were looking to read from a specific device, we've found that read, so no need to continue
@@ -396,12 +396,12 @@ impl AnalogSDK {
             }
 
             if value < 0.0 {
-                return Err(err).into();
+                return Err(err);
             }
 
-            value.into()
+            Ok(value)
         } else {
-            Err(WootingAnalogResult::NoMapping).into()
+            Err(WootingAnalogResult::NoMapping)
         }
     }
 
@@ -409,9 +409,9 @@ impl AnalogSDK {
         &mut self,
         max_length: usize,
         device_id: DeviceID,
-    ) -> SDKResult<HashMap<u16, f32>> {
+    ) -> WootingResult<HashMap<u16, f32>> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
 
         let mut analog_data: HashMap<u16, f32> = HashMap::with_capacity(max_length);
@@ -426,7 +426,7 @@ impl AnalogSDK {
             }
 
             let remaining = max_length.saturating_sub(analog_data.len());
-            let plugin_data = p.read_full_buffer(remaining, device_id).into();
+            let plugin_data = p.read_full_buffer(remaining, device_id);
             match plugin_data {
                 Ok(mut data) => {
                     for (hid_code, analog) in data.drain() {
@@ -459,15 +459,15 @@ impl AnalogSDK {
             }
         }
         if !any_success {
-            return Err(err).into();
+            return Err(err);
         }
 
-        Ok(analog_data).into()
+        Ok(analog_data)
     }
 
     pub(crate) fn read_keycode(&mut self, code: u16, device_id: DeviceID) -> SDKResult<AnalogValue> {
         if !self.initialised {
-            return Err(WootingAnalogResult::UnInitialized).into();
+            return Err(WootingAnalogResult::UnInitialized);
         }
 
         let Some(hid_code) = crate::keycode::code_to_hid(code, &self.keycode_mode) else {
@@ -556,7 +556,7 @@ impl AnalogSDK {
         }
 
         if !any_success {
-            return Err(err).into();
+            return Err(err);
         }
 
         Ok(combined).into()
@@ -593,7 +593,7 @@ impl AnalogSDK {
     pub fn unload(&mut self) {
         debug!("Unloading plugins");
         for mut plugin in self.plugins.drain(..) {
-            let name = plugin.name().0;
+            let name = plugin.name();
             trace!("Firing on_plugin_unload for {:?}", name);
             plugin.unload();
             debug!("Unload successful for {:?}", name);


### PR DESCRIPTION
This PR contains some of the setup for error handling before doing the Rust API. Most of the business logic should remain largely unchanged. The new error types do not get carried over FFI, these are converted to the existing `WootingAnalogResult` variants.

Doing error handling first gives the benefit that the changes stay (relatively) small and minimizes the amount of code changes in any upcoming PR. 

> [!IMPORTANT]  
> Error handling was applied to the `feature/analog-v2-ffi` reworked branch. #130 should be merged first.